### PR TITLE
Assume HTTP/2 protocol on TCP connections

### DIFF
--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -1034,8 +1034,20 @@ defmodule Mint.HTTP2 do
     end
   end
 
-  defp negotiate(hostname, port, scheme, transport_opts) do
-    transport = scheme_to_transport(scheme)
+  defp negotiate(hostname, port, :http, transport_opts) do
+    # We don't support protocol negotiation for TCP connections
+    # so currently we just assume the HTTP/2 protocol
+
+    transport = scheme_to_transport(:http)
+
+    case transport.connect(hostname, port, transport_opts) do
+      {:ok, socket} -> {:ok, socket}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp negotiate(hostname, port, :https, transport_opts) do
+    transport = scheme_to_transport(:https)
 
     with {:ok, socket} <- transport.connect(hostname, port, transport_opts),
          {:ok, protocol} <- transport.negotiated_protocol(socket) do


### PR DESCRIPTION
Mint does not support protocol negotiation on TCP connections (RFC7540 3.2)
so for now we assume the protocol is HTTP/2 in the Mint.HTTP2 module.