### PR TITLE
Add hexdocs.pm and hex.pm badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Mint 🌱
 
 [![Build Status](https://travis-ci.org/elixir-mint/mint.svg?branch=master)](https://travis-ci.org/elixir-mint/mint)
+[![Docs](https://img.shields.io/badge/api-docs-green.svg?style=flat)](https://hexdocs.pm/mint)
+[![Hex.pm Version](http://img.shields.io/hexpm/v/mint.svg?style=flat)](https://hex.pm/packages/mint)
 
 > Functional HTTP client for Elixir with support for HTTP/1 and HTTP/2.
 


### PR DESCRIPTION
This PR adds badges for hexdocs.pm and hex.pm to the README:

![mint-badges](https://user-images.githubusercontent.com/45100/72849748-64e83080-3c75-11ea-8c92-3237572c4a2e.png)

No code was harmed.
