### PR TITLE
Remove compilation from "Install deps" CI step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,9 +48,7 @@ jobs:
           elixir-version: ${{matrix.pair.elixir}}
 
       - name: Install dependencies
-        run: |
-          mix deps.get
-          mix deps.compile
+        run: mix deps.get
 
       - name: Start docker
         run: docker-compose up --detach


### PR DESCRIPTION
`mix deps.compile` was running in the default :dev env, and so when we run `mix test` it compiled everything again in :test as you can see here: https://github.com/elixir-mint/mint/runs/409356642?check_suite_focus=true

An alternative would be to do `MIX_ENV=test mix deps.compile` or maybe `MIX_ENV=test mix compile` as a step between deps and running tests.