### PR TITLE
Move some HTTP/1 tests to httpstat.us

### DIFF
--- a/test/mint/integration_test.exs
+++ b/test/mint/integration_test.exs
@@ -5,35 +5,33 @@ defmodule Mint.IntegrationTest do
 
   alias Mint.{TransportError, HTTP}
 
-  describe "httpbin.org" do
+  describe "httpstat.us" do
     @describetag :integration
 
-    @tag skip: "Seems like httpbin.org added support for HTTP/2 (issue #240)"
     test "SSL - select HTTP1" do
       assert {:ok, conn} =
                HTTP.connect(
                  :https,
-                 "httpbin.org",
+                 "httpstat.us",
                  443
                )
 
       assert conn.__struct__ == Mint.HTTP1
-      assert {:ok, conn, request} = HTTP.request(conn, "GET", "/bytes/1", [], nil)
+      assert {:ok, conn, request} = HTTP.request(conn, "GET", "/200", [], nil)
+
       assert {:ok, _conn, responses} = receive_stream(conn)
 
       assert [
                {:status, ^request, 200},
                {:headers, ^request, _},
-               {:data, ^request, <<_>>},
                {:done, ^request}
              ] = responses
     end
 
-    @tag skip: "Seems like httpbin.org added support for HTTP/2 (issue #240)"
     @tag :capture_log
     test "SSL - fail to select HTTP2" do
       assert {:error, %TransportError{reason: :protocol_not_negotiated}} =
-               HTTP.connect(:https, "httpbin.org", 443,
+               HTTP.connect(:https, "httpstat.us", 443,
                  protocols: [:http2],
                  transport_opts: [reuse_sessions: false]
                )
@@ -140,10 +138,9 @@ defmodule Mint.IntegrationTest do
       assert merge_body(responses, request) =~ "httpbin"
     end
 
-    @tag skip: "Seems like httpbin.org added support for HTTP/2 (issue #240)"
-    test "200 response - https://httpbin.org" do
+    test "200 response - https://httpstat.us" do
       assert {:ok, conn} =
-               HTTP.connect(:https, "httpbin.org", 443, proxy: {:http, "localhost", 8888, []})
+               HTTP.connect(:https, "httpstat.us", 443, proxy: {:http, "localhost", 8888, []})
 
       assert conn.__struct__ == Mint.HTTP1
       assert {:ok, conn, request} = HTTP.request(conn, "GET", "/", [], nil)
@@ -153,7 +150,7 @@ defmodule Mint.IntegrationTest do
       assert {:status, ^request, 200} = status
       assert {:headers, ^request, headers} = headers
       assert is_list(headers)
-      assert merge_body(responses, request) =~ "httpbin"
+      assert merge_body(responses, request) =~ "httpstat.us"
     end
 
     test "200 response with explicit http2 - https://http2.golang.org" do

--- a/test/mint/tunnel_proxy_test.exs
+++ b/test/mint/tunnel_proxy_test.exs
@@ -28,12 +28,11 @@ defmodule Mint.TunnelProxyTest do
     assert merge_body(responses, request) =~ "httpbin"
   end
 
-  @tag skip: "Seems like httpbin.org added support for HTTP/2 (issue #240)"
-  test "200 response - https://httpbin.org" do
+  test "200 response - https://httpstat.us" do
     assert {:ok, conn} =
              Mint.TunnelProxy.connect(
                {:http, "localhost", 8888, []},
-               {:https, "httpbin.org", 443, []}
+               {:https, "httpstat.us", 443, []}
              )
 
     assert conn.__struct__ == Mint.HTTP1
@@ -44,7 +43,7 @@ defmodule Mint.TunnelProxyTest do
     assert {:status, ^request, 200} = status
     assert {:headers, ^request, headers} = headers
     assert is_list(headers)
-    assert merge_body(responses, request) =~ "httpbin"
+    assert merge_body(responses, request) =~ "httpstat.us"
   end
 
   test "407 response - proxy with missing authentication" do
@@ -62,12 +61,11 @@ defmodule Mint.TunnelProxyTest do
              )
   end
 
-  @tag skip: "Seems like httpbin.org added support for HTTP/2 (issue #240)"
   test "200 response - proxy with valid authentication" do
     auth64 = Base.encode64("test:password")
 
     assert {:ok, conn} =
-             Mint.HTTP.connect(:https, "httpbin.org", 443,
+             Mint.HTTP.connect(:https, "httpstat.us", 443,
                proxy: {:http, "localhost", 8889, []},
                proxy_headers: [{"proxy-authorization", "basic #{auth64}"}]
              )
@@ -80,7 +78,7 @@ defmodule Mint.TunnelProxyTest do
     assert {:status, ^request, 200} = status
     assert {:headers, ^request, headers} = headers
     assert is_list(headers)
-    assert merge_body(responses, request) =~ "httpbin"
+    assert merge_body(responses, request) =~ "httpstat.us"
   end
 
   test "200 response with explicit http2 - https://http2.golang.org" do


### PR DESCRIPTION
Closes #240.

Using https://httpstat.us instead of httpbin.org, since it seems reliable and supports HTTP/1 only. I say we go for this for now and if it breaks again we evolve :)

Thanks @prodis for the suggestion!