### PR TITLE
Fix wildcard cert verification on OTP 23

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: ericmj/setup-elixir@patch-2
         with:
-          otp-version: 22.3
-          elixir-version: 1.10.2
+          otp-version: "23.0"
+          elixir-version: "1.10.3"
 
       - name: Install dependencies
         run: mix deps.get
@@ -28,23 +28,23 @@ jobs:
       fail-fast: false
       matrix:
         pair:
-          - erlang: 23.0
-            elixir: 1.10.3
-          - erlang: 22.3
-            elixir: 1.9.4
-          - erlang: 21.3
-            elixir: 1.8.2
-          - erlang: 20.3.1
-            elixir: 1.7.4
-          - erlang: 19.3
-            elixir: 1.6.6
-          - erlang: 18.3
-            elixir: 1.5.3
+          - erlang: "23.0"
+            elixir: "1.10.3"
+          - erlang: "22.3"
+            elixir: "1.9.4"
+          - erlang: "21.3"
+            elixir: "1.8.2"
+          - erlang: "20.3.1"
+            elixir: "1.7.4"
+          - erlang: "19.3"
+            elixir: "1.6.6"
+          - erlang: "18.3"
+            elixir: "1.5.3"
     steps:
       - uses: actions/checkout@v1
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: ericmj/setup-elixir@patch-2
         with:
           otp-version: ${{matrix.pair.erlang}}
           elixir-version: ${{matrix.pair.elixir}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,9 +28,9 @@ jobs:
       fail-fast: false
       matrix:
         pair:
+          - erlang: 23.0
+            elixir: 1.10.3
           - erlang: 22.3
-            elixir: 1.10.2
-          - erlang: 22.1
             elixir: 1.9.4
           - erlang: 21.3
             elixir: 1.8.2

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -476,6 +476,7 @@ defmodule Mint.Core.Transport.SSL do
       versions: @default_versions,
       verify: :verify_peer,
       depth: 4,
+      customize_hostname_check: [match_fun: &match_fun/2],
       secure_renegotiate: true,
       reuse_sessions: true
     ]

--- a/test/mint/http1/integration_test.exs
+++ b/test/mint/http1/integration_test.exs
@@ -75,8 +75,10 @@ defmodule Mint.HTTP1.IntegrationTest do
                )
 
       # OTP 21.3 changes the format of SSL errors. Let's support both ways for now.
+      # Newer OTP versions treat empty list for `cacerts` as if the option was not set
       assert reason == {:tls_alert, 'unknown ca'} or
-               match?({:tls_alert, {:unknown_ca, _}}, reason)
+               match?({:tls_alert, {:unknown_ca, _}}, reason) or
+               reason == {:options, {:cacertfile, []}}
     end
 
     test "keep alive" do


### PR DESCRIPTION
See #259

Note that this is a bit of a departure from the earlier Mint approach to `:ssl`: instead of always using the `:mint_shims` module, even on new OTP versions, we now leave hostname verification to OTP on >=20. We still use Mint's own hostname matching function, which is a subset of OTP's (as described in the comments).

I think this is a good first step in adopting OTP built-in defaults where possible, which are fine for newer versions, and only using the shims for really old OTP versions (until support for them is retired).