### PR TITLE
Fix function names for decompression guide

### DIFF
--- a/pages/Decompression.md
+++ b/pages/Decompression.md
@@ -56,10 +56,10 @@ defp decompress_with_algorithm(gzip, data) when gzip in ["gzip", "x-gzip"],
 defp decompress_with_algorithm("deflate", data),
   do: :zlib.unzip(data)
 
-defp decompress_data("identity", data),
+defp decompress_with_algorithm("identity", data),
   do: data
 
-defp decompress_data(algorithm, data),
+defp decompress_with_algorithm(algorithm, data),
   do: raise "unsupported decompression algorithm: #{inspect(algorithm)}"
 ```
 


### PR DESCRIPTION
Function `decompress_data/2` delegates the real work via `Enum.reduce` to `decompress_with_algorithm/2`.