### PR TITLE
Add TLS 1.3 to default versions

### DIFF
--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -520,7 +520,7 @@ defmodule Mint.Core.Transport.SSL do
     versions = Enum.filter(@default_versions, &(&1 in available_versions))
 
     # Remove buggy TLS 1.3 versions
-    if ssl_version() <= [10, 0] do
+    if ssl_version() < [10, 0] do
       versions -- [:"tlsv1.3"]
     else
       versions

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -291,7 +291,7 @@ defmodule Mint.Core.Transport.SSL do
     active: false
   ]
 
-  @default_versions [:"tlsv1.2"]
+  @default_versions [:"tlsv1.3", :"tlsv1.2"]
   @default_timeout 30_000
 
   Record.defrecordp(

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -436,7 +436,7 @@ defmodule Mint.Core.Transport.SSL do
   end
 
   defp customize_hostname_check(opts, host_or_ip) do
-    if ssl_version() >= {9, 0} do
+    if ssl_version() >= [9, 0] do
       # From OTP 20.0 use built-in support for custom hostname checks
       add_customize_hostname_check(opts)
     else
@@ -519,8 +519,8 @@ defmodule Mint.Core.Transport.SSL do
     available_versions = :ssl.versions()[:available]
     versions = Enum.filter(@default_versions, &(&1 in available_versions))
 
-    # Remove buggy TLS 1.3 for OTP 22.3 and older
-    if ssl_version() <= {9, 6} do
+    # Remove buggy TLS 1.3 versions
+    if ssl_version() <= [10, 0] do
       versions -- [:"tlsv1.3"]
     else
       versions

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -517,7 +517,7 @@ defmodule Mint.Core.Transport.SSL do
 
   defp ssl_versions() do
     available_versions = :ssl.versions()[:available]
-    Enum.filter(@default_versions, & &1 in available_versions)
+    Enum.filter(@default_versions, &(&1 in available_versions))
   end
 
   defp add_cacerts(opts) do

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -507,12 +507,17 @@ defmodule Mint.Core.Transport.SSL do
     [
       ciphers: default_ciphers(),
       server_name_indication: hostname,
-      versions: @default_versions,
+      versions: ssl_versions(),
       verify: :verify_peer,
       depth: 4,
       secure_renegotiate: true,
       reuse_sessions: true
     ]
+  end
+
+  defp ssl_versions() do
+    available_versions = :ssl.versions()[:available]
+    Enum.filter(@default_versions, & &1 in available_versions)
   end
 
   defp add_cacerts(opts) do

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -645,6 +645,5 @@ defmodule Mint.Core.Transport.SSL do
     |> List.to_string()
     |> String.split(".")
     |> Enum.map(&String.to_integer/1)
-    |> List.to_tuple()
   end
 end


### PR DESCRIPTION
It seems to be working correctly in OTP 23 now so it should be safe to add.