### PR TITLE
Fix connection closed errors not propagating, closes #279

### DIFF
--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -265,7 +265,7 @@ defmodule Mint.HTTP1 do
   @doc """
   See `Mint.HTTP.stream_request_body/3`.
 
-  In HTTP/1, sending an empty chuunk is a no-op.
+  In HTTP/1, sending an empty chunk is a no-op.
 
   ## Transfer encoding and content length
 

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -384,14 +384,17 @@ defmodule Mint.HTTP1 do
 
   def stream(%__MODULE__{transport: transport, socket: socket} = conn, {tag, socket, data})
       when tag in [:tcp, :ssl] do
-    result = handle_data(conn, data)
+    case handle_data(conn, data) do
+      {:ok, %{mode: mode, state: state} = conn, responses}
+      when mode == :active and state != :closed ->
+        case transport.setopts(socket, active: :once) do
+          :ok -> {:ok, conn, responses}
+          {:error, reason} -> {:error, put_in(conn.state, :closed), reason, responses}
+        end
 
-    if conn.mode == :active do
-      # TODO: handle errors here.
-      _ = transport.setopts(socket, active: :once)
+      other ->
+        other
     end
-
-    result
   end
 
   def stream(%__MODULE__{socket: socket} = conn, {tag, socket})

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -431,7 +431,9 @@ defmodule Mint.HTTP1Test do
     new_pid =
       spawn_link(fn ->
         receive do
-          message -> send(parent, {ref, message})
+          message ->
+            send(parent, {ref, message})
+            Process.sleep(:infinity)
         end
       end)
 


### PR DESCRIPTION
There is one failing test but I believe the test is wrong. We are transferring the test to another process and then trying to stream its response, which fails when trying to set it back to active mode. I want to change the test but I would like confirmation before.