### PR TITLE
Add :dns_resolver option to :transport_opts for :http and :https

### DIFF
--- a/lib/mint/core/transport/resolver.ex
+++ b/lib/mint/core/transport/resolver.ex
@@ -1,0 +1,19 @@
+defmodule Mint.Core.Transport.Resolver do
+  def resolve(hostname, ipv6, opts) do
+    case Keyword.get(opts, :dns_resolver, :default) do
+      :default ->
+        {:ok, String.to_charlist(hostname)}
+
+      fun ->
+        convert_binary_to_charlist(fun.(hostname, ipv6))
+    end
+  end
+
+  defp convert_binary_to_charlist({:ok, result}) when is_binary(result) do
+    {:ok, String.to_charlist(result)}
+  end
+
+  defp convert_binary_to_charlist(v) do
+    v
+  end
+end

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -239,6 +239,20 @@ defmodule Mint.HTTP do
       seconds), and may be overridden by the caller. Set to `:infinity` to
       disable the connect timeout.
 
+    * `:dns_resolver` - a function used to resolve hostnames to ip addresses or `:default`.
+      `:default` does no resolution and passes the hostname to `:gen_tcp.connect` or
+      `:ssl.connect`. The function takes `(hostname::String.t(), ipv6::boolean())` and
+      should return `{:ok, String.t() | ip_address()}` or `{:error, reason::atom()}`.
+      `ip_address()` is defined in the `:gen_tcp` module and is either a 4-tuple or 8-tuple.
+      If `ipv6` is true the function should return an `ip6_address()` or a hostname otherwise
+      it should return an `ip4_address()` or a hostname.
+      Note: `:dns_resolver` is not useful for preventing SSRF when coupled with using a proxy
+      because in the case of a HTTP proxy the HTTP proxy resolves the host header and in the case
+      of a CONNECT proxy the host is passed to the proxy and the proxy resolves the domain.
+      Note: If using `:dns_resolver` to prevent SSRF be careful with pooling. All requests to a
+      pool need to be using `:dns_resolver` or SSRF filtering will not work as expected.
+
+
   Options for `:https` only:
 
     * `:alpn_advertised_protocols` - managed by Mint. Cannot be overridden.

--- a/test/mint/core/transport/ssl_test.exs
+++ b/test/mint/core/transport/ssl_test.exs
@@ -3,6 +3,19 @@ defmodule Mint.Core.Transport.SSLTest do
 
   alias Mint.Core.Transport.SSL
 
+  test "resolver blocks connections" do
+    block_localhost = fn hostname, _ip6 ->
+      if hostname == "localhost" do
+        {:error, :blocked}
+      else
+        {:ok, hostname}
+      end
+    end
+
+    assert {:error, %Mint.TransportError{reason: :blocked}} ==
+             SSL.connect("localhost", 443, dns_resolver: block_localhost)
+  end
+
   describe "default ciphers" do
     test "no RSA key exchange" do
       # E.g. TLS_RSA_WITH_AES_256_GCM_SHA384 (old and new OTP variants)

--- a/test/mint/core/transport/tcp_test.exs
+++ b/test/mint/core/transport/tcp_test.exs
@@ -1,0 +1,18 @@
+defmodule Mint.Core.Transport.TCPTest do
+  use ExUnit.Case, async: true
+
+  alias Mint.Core.Transport.TCP
+
+  test "resolver blocks connections" do
+    block_localhost = fn hostname, _ip6 ->
+      if hostname == "localhost" do
+        {:error, :blocked}
+      else
+        {:ok, hostname}
+      end
+    end
+
+    assert {:error, %Mint.TransportError{reason: :blocked}} ==
+             TCP.connect("localhost", 443, dns_resolver: block_localhost)
+  end
+end


### PR DESCRIPTION
:dns_resolver can be used to implement SSRF protection.

The :dns_resolver is either :default or a function that takes
the hostname and a boolean indicating whether it is an ip6 resolution
and returns either {:ok, hostname :: String.t() | ip_address()} or
{:error, reason}. In the case of an error it will not connect
except in the situtation of IPv6 to IPv4 fallback where a further
invocation of the resolve function would return an {:ok, X} result.