### PR TITLE
Ignore return value of transport.close/1, for compatibility with new inet_backend: :socket

### DIFF
--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -834,7 +834,7 @@ defmodule Mint.HTTP1 do
       _ = Logger.debug(["Connection closed with data left in the buffer: ", inspect(conn.buffer)])
     end
 
-    :ok = conn.transport.close(conn.socket)
+    _ = conn.transport.close(conn.socket)
     %{conn | state: :closed}
   end
 

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -391,14 +391,8 @@ defmodule Mint.HTTP2 do
   end
 
   def close(%__MODULE__{state: {:goaway, _error_code, _debug_data}} = conn) do
-    case conn.transport.close(conn.socket) do
-      :ok ->
-        conn = put_in(conn.state, :closed)
-        {:ok, conn}
-
-      {:error, reason} ->
-        {:error, conn, reason}
-    end
+    _ = conn.transport.close(conn.socket)
+    {:ok, put_in(conn.state, :closed)}
   end
 
   def close(%__MODULE__{state: :closed} = conn) do
@@ -1963,7 +1957,7 @@ defmodule Mint.HTTP2 do
       goaway(stream_id: 0, last_stream_id: 2, error_code: error_code, debug_data: debug_data)
 
     conn = send!(conn, Frame.encode(frame))
-    :ok = conn.transport.close(conn.socket)
+    _ = conn.transport.close(conn.socket)
     conn = put_in(conn.state, :closed)
     throw({:mint, conn, wrap_error({error_code, debug_data})})
   end

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -366,7 +366,9 @@ defmodule Mint.HTTP1Test do
     refute HTTP1.open?(conn)
   end
 
-  test "close/1 an already closed connection with default inet_backend", %{conn: conn} do
+  test "close/1 an already closed connection with default inet_backend does not cause error", %{
+    conn: conn
+  } do
     assert HTTP1.open?(conn)
     # ignore the returned conn, otherwise transport.close/1 will not be called
     assert {:ok, _conn} = HTTP1.close(conn)
@@ -378,7 +380,9 @@ defmodule Mint.HTTP1Test do
     @tag :skip
   end
 
-  test "close/1 an already closed connection with socket inet_backend", %{port: port} do
+  test "close/1 an already closed connection with socket inet_backend does not cause error", %{
+    port: port
+  } do
     assert {:ok, conn} =
              HTTP1.connect(:http, "localhost", port, transport_opts: [inet_backend: :socket])
 

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -380,7 +380,7 @@ defmodule Mint.HTTP1Test do
 
   test "close/1 an already closed connection with socket inet_backend", %{port: port} do
     assert {:ok, conn} =
-              HTTP1.connect(:http, "localhost", port, transport_opts: [inet_backend: :socket])
+             HTTP1.connect(:http, "localhost", port, transport_opts: [inet_backend: :socket])
 
     assert HTTP1.open?(conn)
     # ignore the returned conn, otherwise transport.close/1 will not be called

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -374,19 +374,19 @@ defmodule Mint.HTTP1Test do
     refute HTTP1.open?(conn)
   end
 
-  erlang_version = :erlang.system_info(:otp_release) |> List.to_integer()
+  if List.to_integer(:erlang.system_info(:otp_release)) < 23 do
+    @tag :skip
+  end
 
-  if erlang_version >= 23 do
-    test "close/1 an already closed connection with socket inet_backend", %{port: port} do
-      assert {:ok, conn} =
-               HTTP1.connect(:http, "localhost", port, transport_opts: [inet_backend: :socket])
+  test "close/1 an already closed connection with socket inet_backend", %{port: port} do
+    assert {:ok, conn} =
+              HTTP1.connect(:http, "localhost", port, transport_opts: [inet_backend: :socket])
 
-      assert HTTP1.open?(conn)
-      # ignore the returned conn, otherwise transport.close/1 will not be called
-      assert {:ok, _conn} = HTTP1.close(conn)
-      assert {:ok, conn} = HTTP1.close(conn)
-      refute HTTP1.open?(conn)
-    end
+    assert HTTP1.open?(conn)
+    # ignore the returned conn, otherwise transport.close/1 will not be called
+    assert {:ok, _conn} = HTTP1.close(conn)
+    assert {:ok, conn} = HTTP1.close(conn)
+    refute HTTP1.open?(conn)
   end
 
   test "request/5 returns an error if the connection is closed", %{conn: conn} do

--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -277,6 +277,16 @@ defmodule Mint.HTTP2Test do
       refute HTTP2.open?(conn)
     end
 
+    test "close/1 an already closed connection with default inet_backend does not cause error", %{
+      conn: conn
+    } do
+      assert HTTP2.open?(conn)
+      # ignore the returned conn, otherwise transport.close/1 will not be called
+      assert {:ok, _conn} = HTTP2.close(conn)
+      assert {:ok, conn} = HTTP2.close(conn)
+      refute HTTP2.open?(conn)
+    end
+
     test "request/5 returns error if the connection is closed",
          %{conn: conn} do
       assert {:error, %HTTP2{} = conn, _error, []} =


### PR DESCRIPTION
I was playing with the new :socket inet_backend and encountered the following MatchError:
```
** (MatchError) no match of right hand side value: {:error, :closed}
    (mint 1.2.0) lib/mint/http1.ex:837: Mint.HTTP1.internal_close/1
    (mint 1.2.0) lib/mint/http1.ex:180: Mint.HTTP1.close/1
```

While `:gen_tcp.close/1` will always return `:ok`, no matter what, the new `:socket.close/1` can return an error tuple.

https://erlang.org/doc/man/gen_tcp.html#close-1
https://erlang.org/doc/man/socket.html#close-1

Perhaps you would prefer to add a Logger.debug message when `conn.transport.close/1` did return an error?