### PR TITLE
Handle connection closed in recv/3

### DIFF
--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -470,6 +470,7 @@ defmodule Mint.HTTP1 do
   def recv(%__MODULE__{mode: :passive} = conn, byte_count, timeout) do
     case conn.transport.recv(conn.socket, byte_count, timeout) do
       {:ok, data} -> handle_data(conn, data)
+      {:error, %Mint.TransportError{reason: :closed}} -> handle_close(conn)
       {:error, error} -> handle_error(conn, error)
     end
   end

--- a/test/mint/http2/integration_test.exs
+++ b/test/mint/http2/integration_test.exs
@@ -150,6 +150,7 @@ defmodule HTTP2.IntegrationTest do
 
   describe "twitter.com" do
     @moduletag connect: {"twitter.com", 443}
+    @browser_user_agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"
 
     test "ping", %{conn: conn} do
       assert {:ok, %HTTP2{} = conn, ref} = HTTP2.ping(conn)
@@ -159,7 +160,8 @@ defmodule HTTP2.IntegrationTest do
     end
 
     test "GET /", %{conn: conn} do
-      assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/", [], nil)
+      assert {:ok, %HTTP2{} = conn, ref} =
+               HTTP2.request(conn, "GET", "/", [{"user-agent", @browser_user_agent}], nil)
 
       assert {:ok, %HTTP2{} = conn, responses} = receive_stream(conn)
 


### PR DESCRIPTION
recv/3 did not correctly handle HTTP/1.0 style responses where the end
of the responses is signalled by the connection closing.

Fixes https://github.com/keathley/finch/issues/111.