### PR TITLE
Clarify that header_value is invalid due to non-ASCII chars

### DIFF
--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -1009,7 +1009,7 @@ defmodule Mint.HTTP1 do
   end
 
   def format_error({:invalid_header_value, name, value}) do
-    "invalid value for header #{inspect(name)}: #{inspect(value)}"
+    "non-ASCII character detected in header #{inspect(name)}: #{inspect(value)}"
   end
 
   def format_error(:invalid_chunk_size) do

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -1009,9 +1009,8 @@ defmodule Mint.HTTP1 do
   end
 
   def format_error({:invalid_header_value, name, value}) do
-    "invalid value for header (only visible ASCII characters are allowed) #{inspect(name)}: #{
-      inspect(value)
-    }"
+    "invalid value for header (only printable ASCII characters are allowed) " <>
+      "#{inspect(name)}: #{inspect(value)}"
   end
 
   def format_error(:invalid_chunk_size) do

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -1009,7 +1009,7 @@ defmodule Mint.HTTP1 do
   end
 
   def format_error({:invalid_header_value, name, value}) do
-    "non-ASCII character detected in header #{inspect(name)}: #{inspect(value)}"
+    "invalid value for header (only visible ASCII characters are allowed) #{inspect(name)}: #{inspect(value)}"
   end
 
   def format_error(:invalid_chunk_size) do

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -1009,7 +1009,9 @@ defmodule Mint.HTTP1 do
   end
 
   def format_error({:invalid_header_value, name, value}) do
-    "invalid value for header (only visible ASCII characters are allowed) #{inspect(name)}: #{inspect(value)}"
+    "invalid value for header (only visible ASCII characters are allowed) #{inspect(name)}: #{
+      inspect(value)
+    }"
   end
 
   def format_error(:invalid_chunk_size) do


### PR DESCRIPTION
- see https://github.com/elixir-mint/mint/issues/301

Also related: https://github.com/elixir-mint/mint/issues/272

Not sure if we should rename `:invalid_header_value` to something like `non_ascii_char_in_header_value`