### PR TITLE
Allow iolists as header values

### DIFF
--- a/lib/mint/http1/request.ex
+++ b/lib/mint/http1/request.ex
@@ -22,9 +22,8 @@ defmodule Mint.HTTP1.Request do
   end
 
   defp encode_headers(headers) do
-    headers
-    |> Enum.map(fn {name, value} -> {name, IO.iodata_to_binary(value)} end)
-    |> Enum.reduce("", fn {name, value}, acc ->
+    Enum.reduce(headers, "", fn {name, value}, acc ->
+      value = IO.iodata_to_binary(value)
       validate_header_name!(name)
       validate_header_value!(name, value)
       [acc, name, ": ", value, "\r\n"]

--- a/lib/mint/http1/request.ex
+++ b/lib/mint/http1/request.ex
@@ -22,7 +22,9 @@ defmodule Mint.HTTP1.Request do
   end
 
   defp encode_headers(headers) do
-    Enum.reduce(headers, "", fn {name, value}, acc ->
+    headers
+    |> Enum.map(fn {name, value} -> {name, IO.iodata_to_binary(value)} end)
+    |> Enum.reduce("", fn {name, value}, acc ->
       validate_header_name!(name)
       validate_header_value!(name, value)
       [acc, name, ": ", value, "\r\n"]

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -547,9 +547,12 @@ defmodule Mint.HTTP2 do
               encode_data(conn, stream_id, "", [:end_stream])
 
             {:eof, trailing_headers} ->
-              lowered_headers = downcase_header_names(trailing_headers)
+              headers =
+                trailing_headers
+                |> downcase_header_names()
+                |> convert_header_value_to_binary()
 
-              if unallowed_trailing_header = Util.find_unallowed_trailing_header(lowered_headers) do
+              if unallowed_trailing_header = Util.find_unallowed_trailing_header(headers) do
                 error = wrap_error({:unallowed_trailing_header, unallowed_trailing_header})
                 throw({:mint, conn, error})
               end

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -478,6 +478,7 @@ defmodule Mint.HTTP2 do
     headers =
       headers
       |> downcase_header_names()
+      |> convert_header_value_to_binary()
       |> add_default_headers(body)
 
     headers = [
@@ -1324,6 +1325,10 @@ defmodule Mint.HTTP2 do
 
   defp downcase_header_names(headers) do
     for {name, value} <- headers, do: {Util.downcase_ascii(name), value}
+  end
+
+  defp convert_header_value_to_binary(headers) do
+    for {name, value} <- headers, do: {name, IO.iodata_to_binary(value)}
   end
 
   defp add_default_headers(headers, body) do

--- a/lib/mint/types.ex
+++ b/lib/mint/types.ex
@@ -55,7 +55,7 @@ defmodule Mint.Types do
   Headers are sent and received as lists of two-element tuples containing two strings,
   the header name and header value.
   """
-  @type headers() :: [{header_name :: String.t(), header_value :: String.t()}]
+  @type headers() :: [{header_name :: String.t(), header_value :: iodata()}]
 
   @typedoc """
   The scheme to use when connecting to an HTTP server.

--- a/lib/mint/types.ex
+++ b/lib/mint/types.ex
@@ -25,7 +25,8 @@ defmodule Mint.Types do
   """
   @type http2_response() ::
           {:pong, request_ref()}
-          | {:push_promise, request_ref(), promised_request_ref :: request_ref(), headers()}
+          | {:push_promise, request_ref(), promised_request_ref :: request_ref(),
+             response_headers()}
 
   @typedoc """
   A response to a request.
@@ -35,7 +36,7 @@ defmodule Mint.Types do
   """
   @type response() ::
           {:status, request_ref(), status()}
-          | {:headers, request_ref(), headers()}
+          | {:headers, request_ref(), response_headers()}
           | {:data, request_ref(), body_chunk :: binary()}
           | {:done, request_ref()}
           | {:error, request_ref(), reason :: term()}
@@ -50,10 +51,18 @@ defmodule Mint.Types do
   @type status() :: non_neg_integer()
 
   @typedoc """
+  HTTP response_headers.
+
+  Mint supports sending iolist in header values, but would only return String.t() as header_value in responses.
+  response_headers are lists of two-element tuples containing two strings,
+  the header name and header value.
+  """
+  @type response_headers() :: [{header_name :: String.t(), header_value :: String.t()}]
+
+  @typedoc """
   HTTP headers.
 
-  Headers are sent and received as lists of two-element tuples containing two strings,
-  the header name and header value.
+  Headers are sent as lists of two-element tuples containing the header name and header value.
   """
   @type headers() :: [{header_name :: String.t(), header_value :: iodata()}]
 

--- a/test/mint/http1/integration_test.exs
+++ b/test/mint/http1/integration_test.exs
@@ -133,22 +133,6 @@ defmodule Mint.HTTP1.IntegrationTest do
       assert merge_body(responses, request) =~ ~s("BODY")
     end
 
-    test "requests with iolist in header values" do
-      headers = [{"content-length", ["1", '4']}]
-      assert {:ok, conn} = HTTP1.connect(:http, "httpbin.org", 80)
-      assert {:ok, conn, request} = HTTP1.request(conn, "POST", "/post", headers, :stream)
-      assert {:ok, conn} = HTTP1.stream_request_body(conn, request, "content")
-      assert {:ok, conn} = HTTP1.stream_request_body(conn, request, " length")
-      assert {:ok, conn} = HTTP1.stream_request_body(conn, request, :eof)
-      assert {:ok, conn, responses} = receive_stream(conn)
-
-      assert conn.buffer == ""
-      assert [status, headers | responses] = responses
-      assert {:status, ^request, 200} = status
-      assert {:headers, ^request, _} = headers
-      assert merge_body(responses, request) =~ ~s("content length")
-    end
-
     test "pipelining" do
       assert {:ok, conn} = HTTP1.connect(:http, "httpbin.org", 80)
       assert {:ok, conn, request1} = HTTP1.request(conn, "GET", "/", [], nil)

--- a/test/mint/http1/request_test.exs
+++ b/test/mint/http1/request_test.exs
@@ -33,6 +33,16 @@ defmodule Mint.HTTP1.RequestTest do
                """)
     end
 
+    test "with iolist in header values" do
+      assert encode_request("POST", "/some-url", [{"foo", ["b", 'a', "r"]}], "hello!") ==
+               request_string("""
+               POST /some-url HTTP/1.1
+               foo: bar
+
+               hello!\
+               """)
+    end
+
     test "validates request target" do
       for invalid_target <- ["/ /", "/%foo", "/foo%x"] do
         assert Request.encode("GET", invalid_target, [], nil) ==

--- a/test/mint/http1/request_test.exs
+++ b/test/mint/http1/request_test.exs
@@ -69,6 +69,11 @@ defmodule Mint.HTTP1.RequestTest do
       assert IO.iodata_to_binary(Request.encode_chunk(:eof)) == "0\r\n\r\n"
     end
 
+    test "{:eof, trailing_headers_with_io_lists}" do
+      assert IO.iodata_to_binary(Request.encode_chunk({:eof, [{"trailing", ["header", 's']}]})) ==
+               "0\r\ntrailing: headers\r\n\r\n"
+    end
+
     test "iodata" do
       iodata = "foo"
       assert IO.iodata_to_binary(Request.encode_chunk(iodata)) == "3\r\nfoo\r\n"

--- a/test/mint/http2/integration_test.exs
+++ b/test/mint/http2/integration_test.exs
@@ -35,6 +35,21 @@ defmodule HTTP2.IntegrationTest do
     assert HTTP2.open?(conn)
   end
 
+  test "requests with iolist in header values" do
+    assert {:ok, %HTTP2{} = conn} = HTTP2.connect(:http, "nghttp2.org", 80)
+
+    assert {:ok, %HTTP2{} = conn, _ref} =
+             HTTP2.request(
+               conn,
+               "GET",
+               "/httpbin/",
+               [{"iolist-header", ["io", 'list', '-', "header"]}],
+               nil
+             )
+
+    assert {:ok, %HTTP2{} = _conn, _responses} = receive_stream(conn)
+  end
+
   describe "http2.golang.org" do
     @describetag connect: {"http2.golang.org", 443}
 


### PR DESCRIPTION
closes #272 

1. this PR uses the silliest solution: calling `IO.iodata_to_binary/1` to convert all the header values to binary first
   1) to fully support iolist, we need to update HPACK module to encode/decode iolist as well, which requires some work (encoding then decoding will no longer be circular) & may still not get the performance boost (may need to convert iolist to binary anyway)
   2) based on my understanding, the main request of #272 is to add iolists support for convenience use, instead of for better performance
   3) so I think we can add this support first, then think of ways to optimize later
2. this PR adds 2 integration tests since I don't know the best place to unit test it. 
    Let me know if there is a better place to test this.