### PR TITLE
Remove `@doc since:` for pre-1.0.0 functions

### DIFF
--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -755,11 +755,6 @@ defmodule Mint.HTTP do
   @spec recv(t(), non_neg_integer(), timeout()) ::
           {:ok, t(), [Types.response()]}
           | {:error, t(), Types.error(), [Types.response()]}
-  # TODO: remove the check when we depend on Elixir 1.7+.
-  if Version.match?(System.version(), ">= 1.7.0") do
-    @doc since: "0.3.0"
-  end
-
   def recv(conn, byte_count, timeout), do: conn_module(conn).recv(conn, byte_count, timeout)
 
   @doc """
@@ -786,11 +781,6 @@ defmodule Mint.HTTP do
   """
   @impl true
   @spec set_mode(t(), :active | :passive) :: {:ok, t()} | {:error, Types.error()}
-  # TODO: remove the check when we depend on Elixir 1.7+.
-  if Version.match?(System.version(), ">= 1.7.0") do
-    @doc since: "0.3.0"
-  end
-
   def set_mode(conn, mode), do: conn_module(conn).set_mode(conn, mode)
 
   @doc """
@@ -827,11 +817,6 @@ defmodule Mint.HTTP do
       end
 
   """
-  # TODO: remove the check when we depend on Elixir 1.7+.
-  if Version.match?(System.version(), ">= 1.7.0") do
-    @doc since: "0.3.0"
-  end
-
   @impl true
   @spec controlling_process(t(), pid()) :: {:ok, t()} | {:error, Types.error()}
   def controlling_process(conn, new_pid), do: conn_module(conn).controlling_process(conn, new_pid)

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -460,11 +460,6 @@ defmodule Mint.HTTP1 do
   @spec recv(t(), non_neg_integer(), timeout()) ::
           {:ok, t(), [Types.response()]}
           | {:error, t(), Types.error(), [Types.response()]}
-  # TODO: remove the check when we depend on Elixir 1.7+.
-  if Version.match?(System.version(), ">= 1.7.0") do
-    @doc since: "0.3.0"
-  end
-
   def recv(conn, byte_count, timeout)
 
   def recv(%__MODULE__{mode: :passive} = conn, byte_count, timeout) do
@@ -484,11 +479,6 @@ defmodule Mint.HTTP1 do
   @doc """
   See `Mint.HTTP.set_mode/2`.
   """
-  # TODO: remove the check when we depend on Elixir 1.7+.
-  if Version.match?(System.version(), ">= 1.7.0") do
-    @doc since: "0.3.0"
-  end
-
   @impl true
   @spec set_mode(t(), :active | :passive) :: {:ok, t()} | {:error, Types.error()}
   def set_mode(%__MODULE__{} = conn, mode) when mode in [:active, :passive] do
@@ -506,11 +496,6 @@ defmodule Mint.HTTP1 do
   @doc """
   See `Mint.HTTP.controlling_process/2`.
   """
-  # TODO: remove the check when we depend on Elixir 1.7+.
-  if Version.match?(System.version(), ">= 1.7.0") do
-    @doc since: "0.3.0"
-  end
-
   @impl true
   @spec controlling_process(t(), pid()) :: {:ok, t()} | {:error, Types.error()}
   def controlling_process(%__MODULE__{} = conn, new_pid) when is_pid(new_pid) do

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -717,10 +717,6 @@ defmodule Mint.HTTP2 do
       {:ok, conn} = Mint.HTTP2.cancel_request(conn, ref)
 
   """
-  if Version.match?(System.version(), ">= 1.7.0") do
-    @doc since: "0.2.0"
-  end
-
   @spec cancel_request(t(), Types.request_ref()) :: {:ok, t()} | {:error, t(), Types.error()}
   def cancel_request(%Mint.HTTP2{} = conn, request_ref) when is_reference(request_ref) do
     case Map.fetch(conn.ref_to_stream_id, request_ref) do
@@ -871,11 +867,6 @@ defmodule Mint.HTTP2 do
   @spec recv(t(), non_neg_integer(), timeout()) ::
           {:ok, t(), [Types.response()]}
           | {:error, t(), Types.error(), [Types.response()]}
-  # TODO: remove the check when we depend on Elixir 1.7+.
-  if Version.match?(System.version(), ">= 1.7.0") do
-    @doc since: "0.3.0"
-  end
-
   def recv(conn, byte_count, timeout)
 
   def recv(%__MODULE__{mode: :passive} = conn, byte_count, timeout) do
@@ -902,11 +893,6 @@ defmodule Mint.HTTP2 do
   @doc """
   See `Mint.HTTP.set_mode/2`.
   """
-  # TODO: remove the check when we depend on Elixir 1.7+.
-  if Version.match?(System.version(), ">= 1.7.0") do
-    @doc since: "0.3.0"
-  end
-
   @impl true
   @spec set_mode(t(), :active | :passive) :: {:ok, t()} | {:error, Types.error()}
   def set_mode(%__MODULE__{} = conn, mode) when mode in [:active, :passive] do
@@ -924,11 +910,6 @@ defmodule Mint.HTTP2 do
   @doc """
   See `Mint.HTTP.controlling_process/2`.
   """
-  # TODO: remove the check when we depend on Elixir 1.7+.
-  if Version.match?(System.version(), ">= 1.7.0") do
-    @doc since: "0.3.0"
-  end
-
   @impl true
   @spec controlling_process(t(), pid()) :: {:ok, t()} | {:error, Types.error()}
   def controlling_process(%__MODULE__{} = conn, new_pid) when is_pid(new_pid) do


### PR DESCRIPTION
Given Mint reached the 1.0 milestone, I don't think `@doc since` on pre-1.0 additions is useful but of course it doesn't hurt either.
