### PR TITLE
Add support for "SSLKEYLOGFILE" environment variable.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - erlang: "23.3.1"
+            elixir: "1.11.4"
           - erlang: "23.0"
             elixir: "1.11.2"
             lint: true

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -661,7 +661,8 @@ defmodule Mint.Core.Transport.SSL do
   defp wrap_err({:error, reason}), do: {:error, wrap_error(reason)}
   defp wrap_err(other), do: other
 
-  defp ssl_version() do
+  @doc false
+  def ssl_version() do
     Application.spec(:ssl, :vsn)
     |> List.to_string()
     |> String.split(".")

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -424,6 +424,14 @@ defmodule Mint.Core.Transport.SSL do
     %Mint.TransportError{reason: reason}
   end
 
+  def connection_information(socket) do
+    wrap_err(:ssl.connection_information(socket))
+  end
+
+  def connection_information(socket, opts) do
+    wrap_err(:ssl.connection_information(socket, opts))
+  end
+
   defp ssl_opts(hostname, opts) do
     default_ssl_opts(hostname)
     |> Keyword.merge(opts)


### PR DESCRIPTION
In order to decrypt TLS sessions in tools like Wireshark, the per-session secrets can be logged to a file. [This document](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format) specifies the file format.

Recent versions of Erlang/OTP have support for getting the `keylog` data for a TLS connection. If a `mint` user wishes to log these secrets to a file, they will export the `SSLKEYLOGFILE` environment variable prior to starting their application. Then, any time a TLS connection is established in this library _and_ that variable is present, the secrets for that connection will be appended to the file.

See "Exporting the Secrets" here: https://erlang.org/doc/apps/ssl/using_ssl.html