### PR TITLE
Drop https options from tcp connection

### DIFF
--- a/lib/mint/core/transport/tcp.ex
+++ b/lib/mint/core/transport/tcp.ex
@@ -8,6 +8,11 @@ defmodule Mint.Core.Transport.TCP do
     mode: :binary,
     active: false
   ]
+  @ssl_opts [
+    :cacertfile, :ciphers, :depth, :partial_chain, :reuse_sessions,
+    :secure_renegotiate, :server_name_indication, :verify, :verify_fun,
+    :versions
+  ]
 
   @default_timeout 30_000
 
@@ -25,6 +30,7 @@ defmodule Mint.Core.Transport.TCP do
       opts
       |> Keyword.merge(@transport_opts)
       |> Keyword.drop([:alpn_advertised_protocols, :timeout, :inet6])
+      |> Keyword.drop(@ssl_opts)
 
     if inet6? do
       # Try inet6 first, then fall back to the defaults provided by

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -556,6 +556,11 @@ defmodule Mint.HTTP1Test do
     end
   end
 
+  test "ignores ssl options on http", %{port: port} do
+    opts = [transport_opts: [verify: :verify_none]]
+    assert {:ok, _conn} = HTTP1.connect(:http, "localhost", port, opts)
+  end
+
   describe "non-streaming requests" do
     test "content-length header is added if not present",
          %{conn: conn, server_socket: server_socket, port: port} do


### PR DESCRIPTION
You might say this is not a right place to put this logic but it can be handy if Mint applies these options only for https.

We use Mint through Finch/Tesla and connection option is given at the start of the application ([Finch.start_link/1](https://hexdocs.pm/finch/Finch.html#start_link/1)). We would like to put TLS options (cacertfile) there but the option will be applied regardless the request scheme. It's fine for https but `:gen_tcp.connect/4` would raise `:badarg` error for these options.

The change ensures these options are dropped when you make non https requests so no error will be raised.

You might argue that I should put these changes on Finch layer (or workaround by having different Finch GenServer for http and https) but I would like to hear what you think.