### PR TITLE
support SETTINGS_ENABLE_CONNECT_PROTOCOL server-side setting

### DIFF
--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -197,7 +197,8 @@ defmodule Mint.HTTP2 do
       max_concurrent_streams: 100,
       initial_window_size: @default_window_size,
       max_frame_size: @default_max_frame_size,
-      max_header_list_size: :infinity
+      max_header_list_size: :infinity,
+      enable_connect_protocol: false
     },
 
     # Settings that the client communicates to the server.
@@ -249,6 +250,10 @@ defmodule Mint.HTTP2 do
 
     * `:max_header_list_size` - (integer) corresponds to `SETTINGS_MAX_HEADER_LIST_SIZE`.
 
+    * `:enable_connect_protocol` - (boolean) corresponds to `SETTINGS_ENABLE_CONNECT_PROTOCOL`.
+      Sets whether the client may invoke the extended connect protocol which is used to
+      bootstrap WebSocket connections.
+
   """
   @type setting() ::
           {:enable_push, boolean()}
@@ -256,6 +261,7 @@ defmodule Mint.HTTP2 do
           | {:initial_window_size, 1..2_147_483_647}
           | {:max_frame_size, 16_384..16_777_215}
           | {:max_header_list_size, :infinity | pos_integer()}
+          | {:enable_connect_protocol, boolean()}
 
   @typedoc """
   HTTP/2 settings.
@@ -1317,6 +1323,12 @@ defmodule Mint.HTTP2 do
           raise ArgumentError, ":max_header_list_size must be an integer, got: #{inspect(value)}"
         end
 
+      {:enable_connect_protocol, value} ->
+        unless is_boolean(value) do
+          raise ArgumentError,
+                ":enable_connect_protocol must be a boolean, got: #{inspect(value)}"
+        end
+
       {name, _value} ->
         raise ArgumentError, "unknown setting parameter #{inspect(name)}"
     end)
@@ -1717,6 +1729,9 @@ defmodule Mint.HTTP2 do
 
       {:max_header_list_size, max_header_list_size}, conn ->
         put_in(conn.server_settings.max_header_list_size, max_header_list_size)
+
+      {:enable_connect_protocol, enable_connect_protocol?}, conn ->
+        put_in(conn.server_settings.enable_connect_protocol, enable_connect_protocol?)
     end)
   end
 

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -198,6 +198,7 @@ defmodule Mint.HTTP2 do
       initial_window_size: @default_window_size,
       max_frame_size: @default_max_frame_size,
       max_header_list_size: :infinity,
+      # Only supported by the server: https://www.rfc-editor.org/rfc/rfc8441.html#section-3
       enable_connect_protocol: false
     },
 

--- a/lib/mint/http2/frame.ex
+++ b/lib/mint/http2/frame.ex
@@ -286,6 +286,7 @@ defmodule Mint.HTTP2.Frame do
         0x04 -> [{:initial_window_size, value} | acc]
         0x05 -> [{:max_frame_size, value} | acc]
         0x06 -> [{:max_header_list_size, value} | acc]
+        0x08 -> [{:enable_connect_protocol, value == 1} | acc]
         _other -> acc
       end
 
@@ -374,6 +375,7 @@ defmodule Mint.HTTP2.Frame do
         {:initial_window_size, value} -> <<0x04::16, value::32>>
         {:max_frame_size, value} -> <<0x05::16, value::32>>
         {:max_header_list_size, value} -> <<0x06::16, value::32>>
+        {:enable_connect_protocol, value} -> <<0x08::16, if(value, do: 1, else: 0)::32>>
       end)
 
     encode_raw(@types[:settings], flags, stream_id, payload)

--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -1251,6 +1251,7 @@ defmodule Mint.HTTP2Test do
     test "get_server_setting/2 can be used to read server settings", %{conn: conn} do
       assert HTTP2.get_server_setting(conn, :max_concurrent_streams) == 100
       assert HTTP2.get_server_setting(conn, :enable_push) == true
+      assert HTTP2.get_server_setting(conn, :enable_connect_protocol) == false
     end
 
     test "get_server_setting/2 fails with unknown settings", %{conn: conn} do

--- a/test/mint/http2/frame_test.exs
+++ b/test/mint/http2/frame_test.exs
@@ -155,14 +155,16 @@ defmodule Mint.HTTP2.FrameTest do
                 max_concurrent_streams <- non_negative_integer(),
                 initial_window_size <- positive_integer(),
                 max_frame_size <- positive_integer(),
-                max_header_list_size <- positive_integer() do
+                max_header_list_size <- positive_integer(),
+                enable_connect_protocol <- boolean() do
         params = [
           header_table_size: header_table_size,
           enable_push: enable_push,
           max_concurrent_streams: max_concurrent_streams,
           initial_window_size: initial_window_size,
           max_frame_size: max_frame_size,
-          max_header_list_size: max_header_list_size
+          max_header_list_size: max_header_list_size,
+          enable_connect_protocol: enable_connect_protocol
         ]
 
         assert_round_trip settings(stream_id: 0, flags: 0x01, params: params)


### PR DESCRIPTION
Hello! :wave:

I'm a huge fan of Mint, thank y'all for maintaining it :slightly_smiling_face:

I've been eyeing [#106](https://github.com/elixir-mint/mint/issues/106) lately and I've been able to get HTTP/1 websockets going with just some minor hacks in [`NFIBrokerage/mint_web_socket`](https://github.com/NFIBrokerage/mint_web_socket). The HTTP/2 bootstrap extends rfc7540's SETTINGS parameters, though, so it looks like we'll need to some changes here to support HTTP/2.

Specifically [rfc8441](https://www.rfc-editor.org/rfc/rfc8441.html) adds a settings param SETTINGS_ENABLE_CONNECT_PROTOCOL with [a new code of `0x8`](https://www.rfc-editor.org/rfc/rfc8441.html#section-9.1) defaulting to `0`.

This PR adds a new `t:Mint.HTTP2.setting/0` `:enable_connect_protocol` defaulting to `false` and the encoding and decoding clauses in `Mint.HTTP2.Frame`.
