### PR TITLE
omit :scheme and :path pseudo-headers in HTTP/2 CONNECT

### DIFF
--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -478,15 +478,9 @@ defmodule Mint.HTTP2 do
     headers =
       headers
       |> downcase_header_names()
+      |> add_pseudo_headers(conn, method, path)
       |> add_default_headers(body)
-
-    headers = [
-      {":method", method},
-      {":path", path},
-      {":scheme", conn.scheme},
-      {":authority", authority_pseudo_header(conn.scheme, conn.port, conn.hostname)}
-      | headers
-    ]
+      |> sort_pseudo_headers_to_front()
 
     {conn, stream_id, ref} = open_stream(conn)
 
@@ -1321,6 +1315,30 @@ defmodule Mint.HTTP2 do
   defp add_default_content_length_header(headers, body) do
     Util.put_new_header_lazy(headers, "content-length", fn ->
       body |> IO.iodata_length() |> Integer.to_string()
+    end)
+  end
+
+  defp add_pseudo_headers(headers, conn, "CONNECT", _path) do
+    [
+      {":method", "CONNECT"},
+      {":authority", authority_pseudo_header(conn.scheme, conn.port, conn.hostname)}
+      | headers
+    ]
+  end
+
+  defp add_pseudo_headers(headers, conn, method, path) do
+    [
+      {":method", method},
+      {":path", path},
+      {":scheme", conn.scheme},
+      {":authority", authority_pseudo_header(conn.scheme, conn.port, conn.hostname)}
+      | headers
+    ]
+  end
+
+  defp sort_pseudo_headers_to_front(headers) do
+    Enum.sort_by(headers, fn {key, _value} ->
+      not String.starts_with?(key, ":")
     end)
   end
 

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -1333,6 +1333,7 @@ defmodule Mint.HTTP2 do
         {":authority", authority_pseudo_header(conn.scheme, conn.port, conn.hostname)}
         | headers
       ]
+    end
   end
 
   defp sort_pseudo_headers_to_front(headers) do

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -1318,22 +1318,21 @@ defmodule Mint.HTTP2 do
     end)
   end
 
-  defp add_pseudo_headers(headers, conn, "CONNECT", _path) do
-    [
-      {":method", "CONNECT"},
-      {":authority", authority_pseudo_header(conn.scheme, conn.port, conn.hostname)}
-      | headers
-    ]
-  end
-
   defp add_pseudo_headers(headers, conn, method, path) do
-    [
-      {":method", method},
-      {":path", path},
-      {":scheme", conn.scheme},
-      {":authority", authority_pseudo_header(conn.scheme, conn.port, conn.hostname)}
-      | headers
-    ]
+    if String.upcase(method) == "CONNECT" do
+      [
+        {":method", method},
+        {":authority", authority_pseudo_header(conn.scheme, conn.port, conn.hostname)}
+        | headers
+      ]
+    else
+      [
+        {":method", method},
+        {":path", path},
+        {":scheme", conn.scheme},
+        {":authority", authority_pseudo_header(conn.scheme, conn.port, conn.hostname)}
+        | headers
+      ]
   end
 
   defp sort_pseudo_headers_to_front(headers) do

--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -599,6 +599,47 @@ defmodule Mint.HTTP2Test do
 
       assert cookie == "a=b; c=d; e=f; g=h"
     end
+
+    test "a CONNECT request omits :scheme and :path pseudo-headers", %{conn: conn} do
+      assert {:ok, conn, _ref} = HTTP2.request(conn, "CONNECT", "/", [], nil)
+
+      assert_recv_frames [headers(hbf: hbf)]
+
+      refute hbf
+             |> server_decode_headers()
+             |> List.keymember?(":scheme", 0)
+
+      refute hbf
+             |> server_decode_headers()
+             |> List.keymember?(":path", 0)
+
+      assert HTTP2.open?(conn)
+    end
+
+    test "explicitly passed pseudo-headers are sorted to the front of the headers list", %{
+      conn: conn
+    } do
+      headers = [
+        {":scheme", conn.scheme},
+        {":path", "/ws"},
+        {":protocol", "websocket"}
+      ]
+
+      assert {:ok, conn, _ref} = HTTP2.request(conn, "CONNECT", "/", headers, :stream)
+
+      assert_recv_frames [headers(hbf: hbf)]
+
+      assert [
+               {":method", "CONNECT"},
+               {":authority", _},
+               {":scheme", _},
+               {":path", "/ws"},
+               {":protocol", "websocket"},
+               {"user-agent", _}
+             ] = hbf |> server_decode_headers()
+
+      assert HTTP2.open?(conn)
+    end
   end
 
   describe "trailing headers" do

--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -636,7 +636,7 @@ defmodule Mint.HTTP2Test do
                {":path", "/ws"},
                {":protocol", "websocket"},
                {"user-agent", _}
-             ] = hbf |> server_decode_headers()
+             ] = server_decode_headers(hbf)
 
       assert HTTP2.open?(conn)
     end


### PR DESCRIPTION
Hi again :slightly_smiling_face:

Like #321, this PR is for the sake of HTTP/2 bootstrap for WebSockets.

This PR makes two changes:

- omit `:scheme` and `:path` pseudo-headers in `Mint.HTTP2.request/5` when the `method` is `"CONNECT"`
- sort pseudo-headers to the front of the headers list
    - this allows one to pass pseudo-header(s) to `Mint.HTTP2.request/5`

For the first part, I was skimming around rfc7540's section on [the CONNECT method](https://datatracker.ietf.org/doc/html/rfc7540#section-8.3) and found a MUST for CONNECT requests:

> The ":scheme" and ":path" pseudo-header fields MUST be omitted.

The second part is for the sake of the WebSocket bootstrap: rfc8441's section on [extending the CONNECT method](https://datatracker.ietf.org/doc/html/rfc8441#section-4) adds "A new pseudo-header field :protocol..." and also says

> On requests that contain the :protocol pseudo-header field, the :scheme and :path pseudo-header fields of the target URI (see Section 5) MUST also be included.

The difficulty is that with the current `request/5` implementation, the `user-agent` header gets interspersed between any headers explicitly passed. For example:

```elixir
headers = [{":protocol", "websocket"}]
Mint.HTTP.request(conn, "CONNECT", "/", headers, :stream)
```

Would end up with a set of headers like so:

```
:method CONNECT
:path /
:scheme http
:authority h2server:7070
user-agent mint/1.3.0
:protocol websocket
```

Which conflicts with rfc7540 section 8.1.2.1 on pseudo-header fields:

> All pseudo-header fields MUST appear in the header block before regular header fields.

With these changes I'm getting some good results sending/receiving frames against an [example h2 WebSocket fixture](https://github.com/NFIBrokerage/mint_web_socket/pull/9/files#diff-7b24d3f8120696e6bfaf47c312b0b05333561dc9b003a3e4b660b5a23280db46R12-R17)! :tada: