### PR TITLE
Fix scheme() type

### DIFF
--- a/lib/mint/types.ex
+++ b/lib/mint/types.ex
@@ -60,7 +60,7 @@ defmodule Mint.Types do
   @typedoc """
   The scheme to use when connecting to an HTTP server.
   """
-  @type scheme() :: :http | :https
+  @type scheme() :: :http | :https | module()
 
   @typedoc """
   An error reason.


### PR DESCRIPTION
Functions like connect/4 that use scheme_to_transport/1 subsequentially
allow for modules to be used as a scheme.
The scheme type now reflects this.