### PR TITLE
add Mint.HTTP.module/1 to describe the conn module given a conn

### DIFF
--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -386,7 +386,6 @@ defmodule Mint.HTTP do
   """
   @spec protocol(t()) :: :http1 | :http2
   def protocol(%Mint.HTTP1{}), do: :http1
-  def protocol(%Mint.UnsafeProxy{}), do: :http1
   def protocol(%Mint.HTTP2{}), do: :http2
 
   @doc false

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -388,7 +388,10 @@ defmodule Mint.HTTP do
       iex> Mint.HTTP.protocol(%Mint.HTTP2{})
       :http2
   """
-  @doc since: "1.4.0"
+  if Version.compare(System.version(), "1.7.0") in [:eq, :gt] do
+    @doc since: "1.4.0"
+  end
+
   @spec protocol(t()) :: :http1 | :http2
   def protocol(%Mint.HTTP1{}), do: :http1
   def protocol(%Mint.HTTP2{}), do: :http2

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -382,7 +382,7 @@ defmodule Mint.HTTP do
 
   ## Examples
 
-      Mint.HTTP1 = Mint.HTTP.module(conn)
+      :http1 = Mint.HTTP.protocol(conn)
   """
   @spec protocol(t()) :: :http1 | :http2
   def protocol(%Mint.HTTP1{}), do: :http1

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -378,15 +378,21 @@ defmodule Mint.HTTP do
     do: Mint.Negotiate.upgrade(old_transport, transport_state, scheme, hostname, port, opts)
 
   @doc """
-  Returns an atom describing the current connection type
+  Returns the protocol used by the current connection.
 
   ## Examples
 
-      :http1 = Mint.HTTP.protocol(conn)
+      iex> Mint.HTTP.protocol(%Mint.HTTP1{})
+      :http1
+
+      iex> Mint.HTTP.protocol(%Mint.HTTP2{})
+      :http2
   """
+  @doc since: "1.4.0"
   @spec protocol(t()) :: :http1 | :http2
   def protocol(%Mint.HTTP1{}), do: :http1
   def protocol(%Mint.HTTP2{}), do: :http2
+  def protocol(%Mint.UnsafeProxy{state: internal_conn}), do: protocol(internal_conn)
 
   @doc false
   @impl true

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -377,6 +377,17 @@ defmodule Mint.HTTP do
   def upgrade(old_transport, transport_state, scheme, hostname, port, opts),
     do: Mint.Negotiate.upgrade(old_transport, transport_state, scheme, hostname, port, opts)
 
+  @doc """
+  Returns an atom describing the current connection type
+
+  ## Examples
+
+      Mint.HTTP1 = Mint.HTTP.module(conn)
+  """
+  @spec module(t()) :: atom()
+  def module(%Mint.HTTP1{}), do: Mint.HTTP1
+  def module(%Mint.HTTP2{}), do: Mint.HTTP2
+
   @doc false
   @impl true
   @spec initiate(

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -384,9 +384,10 @@ defmodule Mint.HTTP do
 
       Mint.HTTP1 = Mint.HTTP.module(conn)
   """
-  @spec module(t()) :: atom()
-  def module(%Mint.HTTP1{}), do: Mint.HTTP1
-  def module(%Mint.HTTP2{}), do: Mint.HTTP2
+  @spec protocol(t()) :: :http1 | :http2
+  def protocol(%Mint.HTTP1{}), do: :http1
+  def protocol(%Mint.UnsafeProxy{}), do: :http1
+  def protocol(%Mint.HTTP2{}), do: :http2
 
   @doc false
   @impl true

--- a/test/http_test.exs
+++ b/test/http_test.exs
@@ -1,0 +1,4 @@
+defmodule Mint.HTTPTest do
+  use ExUnit.Case, async: true
+  doctest Mint.HTTP
+end


### PR DESCRIPTION
@ericmj it seems like that could also be achieved by making `Mint.HTTP.conn_module` public, but I'm not sure about `UnsafeProxy`. Since it uses `Mint.HTTP1` under the hood should we return `Mint.HTTP1?` `UnsafeProxy`? I don't really know what `UnsafeProxy` gets used for, guessing non-https proxying