### PR TITLE
Prevent open requests from leaking when HTTP2.request or HTTP2. stream_request_body return an error

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -5,6 +5,7 @@
   locals_without_parens: [
     assert_round_trip: 1,
     assert_recv_frames: 1,
-    assert_http2_error: 2
+    assert_http2_error: 2,
+    assert_transport_error: 2
   ]
 ]

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -498,8 +498,7 @@ defmodule Mint.HTTP2 do
       {:ok, conn, ref}
     catch
       :throw, {:mint, _conn, reason} ->
-        # Revert the connection to the original version before we tried to do the request,
-        # to clean up any tracking we added to conn for the request that no longer exists.
+        # The stream is invalid and "_conn" may be tracking it, so we return the original connection instead.
         {:error, original_conn, reason}
     end
   end
@@ -539,8 +538,7 @@ defmodule Mint.HTTP2 do
           {:ok, conn}
         catch
           :throw, {:mint, _conn, reason} ->
-            # Revert the connection to the original version before we tried to do the request,
-            # to clean up any tracking we added to conn for the request that no longer exists.
+            # The stream is invalid and "_conn" may be tracking it, so we return the original connection instead.
             {:error, original_conn, reason}
         end
       :error ->

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -507,8 +507,7 @@ defmodule Mint.HTTP2 do
           t(),
           Types.request_ref(),
           iodata() | :eof | {:eof, trailing_headers :: Types.headers()}
-        ) ::
-          {:ok, t()} | {:error, t(), Types.error()}
+        ) :: {:ok, t()} | {:error, t(), Types.error()}
   def stream_request_body(conn, request_ref, chunk)
 
   def stream_request_body(%Mint.HTTP2{state: :closed} = conn, _request_ref, _chunk) do
@@ -527,9 +526,9 @@ defmodule Mint.HTTP2 do
       when is_reference(request_ref) do
     case Map.fetch(conn.ref_to_stream_id, request_ref) do
       {:ok, stream_id} ->
-          {conn, payload} = encode_stream_body_request_payload(conn, stream_id, chunk)
-          conn = send!(conn, payload)
-          {:ok, conn}
+        {conn, payload} = encode_stream_body_request_payload(conn, stream_id, chunk)
+        conn = send!(conn, payload)
+        {:ok, conn}
 
       :error ->
         {:error, conn, wrap_error(:unknown_request_to_stream)}

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -492,7 +492,7 @@ defmodule Mint.HTTP2 do
     {conn, stream_id, ref} = open_stream(conn)
 
     try do
-      {conn, payload} = encode_payload(conn, stream_id, headers, body)
+      {conn, payload} = encode_request_payload(conn, stream_id, headers, body)
       conn = send!(conn, payload)
       {:ok, conn, ref}
     catch
@@ -1092,7 +1092,7 @@ defmodule Mint.HTTP2 do
     {conn, stream.id, stream.ref}
   end
 
-  defp encode_payload(conn, stream_id, headers, body) do
+  defp encode_request_payload(conn, stream_id, headers, body) do
     case body do
       :stream ->
         encode_headers(conn, stream_id, headers, [:end_headers])

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -1100,7 +1100,7 @@ defmodule Mint.HTTP2 do
       nil ->
         encode_headers(conn, stream_id, headers, [:end_stream, :end_headers])
 
-      _iodata ->
+      body ->
         {conn, headers_payload} = encode_headers(conn, stream_id, headers, [:end_headers])
         {conn, data_payload} = encode_data(conn, stream_id, body, [:end_stream])
         {conn, [headers_payload, data_payload]}

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -1092,19 +1092,18 @@ defmodule Mint.HTTP2 do
     {conn, stream.id, stream.ref}
   end
 
-  defp encode_request_payload(conn, stream_id, headers, body) do
-    case body do
-      :stream ->
-        encode_headers(conn, stream_id, headers, [:end_headers])
+  defp encode_request_payload(conn, stream_id, headers, :stream) do
+    encode_headers(conn, stream_id, headers, [:end_headers])
+  end
 
-      nil ->
-        encode_headers(conn, stream_id, headers, [:end_stream, :end_headers])
+  defp encode_request_payload(conn, stream_id, headers, nil) do
+    encode_headers(conn, stream_id, headers, [:end_stream, :end_headers])
+  end
 
-      body ->
-        {conn, headers_payload} = encode_headers(conn, stream_id, headers, [:end_headers])
-        {conn, data_payload} = encode_data(conn, stream_id, body, [:end_stream])
-        {conn, [headers_payload, data_payload]}
-    end
+  defp encode_request_payload(conn, stream_id, headers, iodata) do
+    {conn, headers_payload} = encode_headers(conn, stream_id, headers, [:end_headers])
+    {conn, data_payload} = encode_data(conn, stream_id, iodata, [:end_stream])
+    {conn, [headers_payload, data_payload]}
   end
 
   defp encode_headers(conn, stream_id, headers, enabled_flags) do

--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -361,7 +361,7 @@ defmodule Mint.HTTP2Test do
 
       Enum.reduce([nil, :stream, "XX"], conn, fn body, conn ->
         assert {:error, %HTTP2{} = conn, error} = HTTP2.request(conn, "GET", "/", [], body)
-        assert_transport_error error, :timeout
+        assert_transport_error(error, :timeout)
 
         assert HTTP2.open_request_count(conn) == 0
         assert HTTP2.open?(conn)
@@ -383,7 +383,7 @@ defmodule Mint.HTTP2Test do
 
       data = :binary.copy(<<0>>, HTTP2.get_window_size(conn, {:request, ref}))
       assert {:error, %HTTP2{} = conn, error} = HTTP2.stream_request_body(conn, ref, data)
-      assert_transport_error error, :timeout
+      assert_transport_error(error, :timeout)
 
       assert HTTP2.open_request_count(conn) == 1
       assert HTTP2.open?(conn)
@@ -614,8 +614,7 @@ defmodule Mint.HTTP2Test do
 
       assert hbf
              |> server_decode_headers()
-             |> List.keyfind("content-length", 0) ==
-               {"content-length", "5"}
+             |> List.keyfind("content-length", 0) == {"content-length", "5"}
 
       # Let's check that content-length is not overridden if already present.
 
@@ -626,8 +625,7 @@ defmodule Mint.HTTP2Test do
 
       assert hbf
              |> server_decode_headers()
-             |> List.keyfind("content-length", 0) ==
-               {"content-length", "10"}
+             |> List.keyfind("content-length", 0) == {"content-length", "10"}
 
       # Let's make sure content-length isn't added if the body is nil or :stream.
 

--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -361,7 +361,7 @@ defmodule Mint.HTTP2Test do
 
       Enum.reduce([nil, :stream, "XX"], conn, fn body, conn ->
         assert {:error, %HTTP2{} = conn, error} = HTTP2.request(conn, "GET", "/", [], body)
-        assert_transport_error(error, :timeout)
+        assert_transport_error error, :timeout
 
         assert HTTP2.open_request_count(conn) == 0
         assert HTTP2.open?(conn)
@@ -383,7 +383,7 @@ defmodule Mint.HTTP2Test do
 
       data = :binary.copy(<<0>>, HTTP2.get_window_size(conn, {:request, ref}))
       assert {:error, %HTTP2{} = conn, error} = HTTP2.stream_request_body(conn, ref, data)
-      assert_transport_error(error, :timeout)
+      assert_transport_error error, :timeout
 
       assert HTTP2.open_request_count(conn) == 1
       assert HTTP2.open?(conn)

--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -301,12 +301,13 @@ defmodule Mint.HTTP2Test do
 
       test_bodies = [nil, :stream, "XX"]
 
-      Enum.reduce(test_bodies, conn, fn body, conn ->
-        assert {:error, %HTTP2{} = conn, error} = HTTP2.request(conn, "GET", "/", [], body)
-        assert_http2_error error, :closed_for_writing
-        assert HTTP2.open_request_count(conn) == 0
-        conn
-      end)
+      conn =
+        Enum.reduce(test_bodies, conn, fn body, conn ->
+          assert {:error, %HTTP2{} = conn, error} = HTTP2.request(conn, "GET", "/", [], body)
+          assert_http2_error error, :closed_for_writing
+          assert HTTP2.open_request_count(conn) == 0
+          conn
+        end)
 
       assert {:ok, conn} = HTTP2.close(conn)
 

--- a/test/support/mint/http2/test_transport_send_timeout.ex
+++ b/test/support/mint/http2/test_transport_send_timeout.ex
@@ -1,0 +1,23 @@
+defmodule Mint.HTTP2.TestTransportSendTimeout do
+  @behaviour Mint.Core.Transport
+
+  @real_module Mint.Core.Transport.SSL
+
+  defdelegate connect(address, port, opts), to: @real_module
+  defdelegate upgrade(socket, original_scheme, hostname, port, opts), to: @real_module
+  defdelegate negotiated_protocol(socket), to: @real_module
+
+  def send(socket, payload) do
+    case @real_module.send(socket, payload) do
+      :ok -> {:error, wrap_error(:timeout)}
+      error -> error
+    end
+  end
+
+  defdelegate close(socket), to: @real_module
+  defdelegate recv(socket, bytes, timeout), to: @real_module
+  defdelegate controlling_process(socket, pid), to: @real_module
+  defdelegate setopts(socket, opts), to: @real_module
+  defdelegate getopts(socket, opts), to: @real_module
+  defdelegate wrap_error(reason), to: @real_module
+end


### PR DESCRIPTION
Hello, and thank you for the great library!

## Issue Description

HTTP2 leaks open requests in some cases when there are errors raised in `HTTP2.request/5`.

## Background

I ran into this when hitting `:exceeds_window_size` and `:too_many_concurrent_requests` errors in production.
We get some of these errors during the normal operation of our service, and each one leaks a request. When this happens, we retry our request on a different HTTP2 connection, so the leak was not noticeable for a long time.

## Impact of the issue

Unfortunately we can eventually end up with enough leaked requests so that every HTTP2 request will error with `:too_many_concurrent_requests`. This leaves the HTTP2 connection in a bad state where it will no longer work.

## PR Changes

This PR introduces some logic to clean up these errored requests, and adds a few checks to the tests to confirm the fix.