### PR TITLE
Add proxy_headers field to HTTP structs and fill this field in tunnel proxy

### DIFF
--- a/lib/mint/core/conn.ex
+++ b/lib/mint/core/conn.ex
@@ -56,4 +56,6 @@ defmodule Mint.Core.Conn do
   @callback delete_private(conn(), key :: atom()) :: conn()
 
   @callback get_socket(conn()) :: Mint.Types.socket()
+
+  @callback get_proxy_headers(conn()) :: Mint.Types.headers()
 end

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -913,7 +913,8 @@ defmodule Mint.HTTP do
   @doc """
   Gets the proxy headers associated with the connection in the `CONNECT` method.
 
-  When using tunnel proxy and https there is the only way to exchange data with the proxy is through headers in the `CONNECT` method.
+  When using tunnel proxy and HTTPs, the only way to exchange data with
+  the proxy is through headers in the `CONNECT` method.
   """
   @impl true
   @spec get_proxy_headers(t()) :: Mint.Types.headers()

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -910,6 +910,15 @@ defmodule Mint.HTTP do
   @spec get_socket(t()) :: Mint.Types.socket()
   def get_socket(conn), do: conn_module(conn).get_socket(conn)
 
+  @doc """
+  Gets the proxy headers associated with the connection in the `CONNECT` method.
+
+  When using tunnel proxy and https there is the only way to exchange data with the proxy is through headers in the `CONNECT` method.
+  """
+  @impl true
+  @spec get_proxy_headers(t()) :: Mint.Types.headers()
+  def get_proxy_headers(conn), do: conn_module(conn).get_proxy_headers(conn)
+
   ## Helpers
 
   defp conn_module(%UnsafeProxy{}), do: UnsafeProxy

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -91,6 +91,7 @@ defmodule Mint.HTTP1 do
     requests: :queue.new(),
     state: :closed,
     buffer: "",
+    proxy_headers: [],
     private: %{}
   ]
 
@@ -562,6 +563,13 @@ defmodule Mint.HTTP1 do
   def get_socket(%__MODULE__{socket: socket} = _conn) do
     socket
   end
+
+  @doc """
+  See `Mint.HTTP.get_proxy_headers/1`.
+  """
+  @impl true
+  @spec get_proxy_headers(t()) :: Mint.Types.headers()
+  def get_proxy_headers(%__MODULE__{proxy_headers: proxy_headers}), do: proxy_headers
 
   ## Helpers
 

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -213,6 +213,9 @@ defmodule Mint.HTTP2 do
     # the continuation frames must come one right after the other).
     headers_being_processed: nil,
 
+    # Stores the headers returned by the proxy in the `CONNECT` method
+    proxy_headers: [],
+
     # Private store.
     private: %{}
   ]
@@ -980,6 +983,13 @@ defmodule Mint.HTTP2 do
   def get_socket(%Mint.HTTP2{socket: socket} = _conn) do
     socket
   end
+
+  @doc """
+  See `Mint.HTTP.get_proxy_headers/1`.
+  """
+  @impl true
+  @spec get_proxy_headers(t()) :: Mint.Types.headers()
+  def get_proxy_headers(%__MODULE__{proxy_headers: proxy_headers}), do: proxy_headers
 
   ## Helpers
 

--- a/lib/mint/unsafe_proxy.ex
+++ b/lib/mint/unsafe_proxy.ex
@@ -179,4 +179,12 @@ defmodule Mint.UnsafeProxy do
   def get_socket(%UnsafeProxy{module: module, state: state}) do
     module.get_socket(state)
   end
+
+  @doc """
+  The `%__MODULE__{proxy_headers: value}` here is the request headers, not the proxy response ones.
+  Unsafe proxy mixes its headers (if any) with the regular response headers, so you can get them there.
+  """
+  @impl true
+  @spec get_proxy_headers(t()) :: Mint.Types.headers()
+  def get_proxy_headers(%__MODULE__{}), do: []
 end

--- a/lib/mint/unsafe_proxy.ex
+++ b/lib/mint/unsafe_proxy.ex
@@ -180,10 +180,9 @@ defmodule Mint.UnsafeProxy do
     module.get_socket(state)
   end
 
-  @doc """
-  The `%__MODULE__{proxy_headers: value}` here is the request headers, not the proxy response ones.
-  Unsafe proxy mixes its headers (if any) with the regular response headers, so you can get them there.
-  """
+  # The `%__MODULE__{proxy_headers: value}` here is the request headers,
+  # not the proxy response ones. Unsafe proxy mixes its headers (if any)
+  # with the regular response headers, so you can get them there.
   @impl true
   @spec get_proxy_headers(t()) :: Mint.Types.headers()
   def get_proxy_headers(%__MODULE__{}), do: []

--- a/test/mint/tunnel_proxy_test.exs
+++ b/test/mint/tunnel_proxy_test.exs
@@ -18,6 +18,10 @@ defmodule Mint.TunnelProxyTest do
              )
 
     assert conn.__struct__ == Mint.HTTP1
+
+    assert [{"proxy-agent", <<"tinyproxy/", _version::binary>>}] =
+             Mint.HTTP1.get_proxy_headers(conn)
+
     assert {:ok, conn, request} = HTTP.request(conn, "GET", "/", [], nil)
     assert {:ok, _conn, responses} = receive_stream(conn)
 
@@ -87,6 +91,10 @@ defmodule Mint.TunnelProxyTest do
              )
 
     assert conn.__struct__ == Mint.HTTP2
+
+    assert [{"proxy-agent", <<"tinyproxy/", _version::binary>>}] =
+             Mint.HTTP2.get_proxy_headers(conn)
+
     assert {:ok, conn, request} = HTTP.request(conn, "GET", "/reqinfo", [], nil)
     assert {:ok, _conn, responses} = receive_stream(conn)
 
@@ -105,6 +113,10 @@ defmodule Mint.TunnelProxyTest do
              )
 
     assert conn.__struct__ == Mint.HTTP2
+
+    assert [{"proxy-agent", <<"tinyproxy/", _version::binary>>}] =
+             Mint.HTTP.get_proxy_headers(conn)
+
     assert {:ok, conn, request} = HTTP.request(conn, "GET", "/reqinfo", [], nil)
     assert {:ok, _conn, responses} = receive_stream(conn)
 
@@ -124,6 +136,10 @@ defmodule Mint.TunnelProxyTest do
              )
 
     assert conn.__struct__ == Mint.HTTP1
+
+    assert [{"proxy-agent", <<"tinyproxy/", _version::binary>>}] =
+             Mint.HTTP.get_proxy_headers(conn)
+
     assert {:ok, conn, request} = HTTP.request(conn, "GET", "/", [], nil)
     assert {:ok, _conn, responses} = receive_stream(conn)
 


### PR DESCRIPTION
When connecting over HTTPS the only way to talk with proxy server is sending and receiving headers on connect method. 