### PR TITLE
Let's Encrypt long chain integration test

### DIFF
--- a/test/mint/integration_test.exs
+++ b/test/mint/integration_test.exs
@@ -126,6 +126,11 @@ defmodule Mint.IntegrationTest do
 
     @dst_and_isrg Path.expand("../support/mint/dst_and_isrg.pem", __DIR__)
 
+    # OTP 18.3 fails to connect to letsencrypt.org, skip this test
+    if Mint.Core.Transport.SSL.ssl_version() < [8, 0] do
+      @tag skip: ":ssl version too old"
+    end
+
     # This test assumes the letsencrypt.org server presents the 'long chain',
     # consisting of the following certificates:
     #
@@ -139,7 +144,7 @@ defmodule Mint.IntegrationTest do
     # This is currently the case, but won't be the case after Sep 2024, or
     # possibly earlier.
     test "Let's Encrypt ISRG cross-signed by expired root" do
-      assert {:ok, conn} =
+      assert {:ok, _conn} =
                HTTP.connect(:https, "letsencrypt.org", 443,
                  transport_opts: [cacertfile: @dst_and_isrg, reuse_sessions: false]
                )

--- a/test/mint/integration_test.exs
+++ b/test/mint/integration_test.exs
@@ -121,6 +121,31 @@ defmodule Mint.IntegrationTest do
     end
   end
 
+  describe "partial chain handling" do
+    @describetag :integration
+
+    @dst_and_isrg Path.expand("../support/mint/dst_and_isrg.pem", __DIR__)
+
+    # This test assumes the letsencrypt.org server presents the 'long chain',
+    # consisting of the following certificates:
+    #
+    #  0 s:/CN=lencr.org
+    #    i:/C=US/O=Let's Encrypt/CN=R3
+    #  1 s:/C=US/O=Let's Encrypt/CN=R3
+    #    i:/C=US/O=Internet Security Research Group/CN=ISRG Root X1
+    #  2 s:/C=US/O=Internet Security Research Group/CN=ISRG Root X1
+    #    i:/O=Digital Signature Trust Co./CN=DST Root CA X3
+    #
+    # This is currently the case, but won't be the case after Sep 2024, or
+    # possibly earlier.
+    test "Let's Encrypt ISRG cross-signed by expired root" do
+      assert {:ok, conn} =
+               HTTP.connect(:https, "letsencrypt.org", 443,
+                 transport_opts: [cacertfile: @dst_and_isrg, reuse_sessions: false]
+               )
+    end
+  end
+
   describe "proxy" do
     @describetag :proxy
 

--- a/test/support/mint/dst_and_isrg.pem
+++ b/test/support/mint/dst_and_isrg.pem
@@ -1,0 +1,96 @@
+### Digital Signature Trust Co.
+
+=== /O=Digital Signature Trust Co./CN=DST Root CA X3
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            44:af:b0:80:d6:a3:27:ba:89:30:39:86:2e:f8:40:6b
+    Signature Algorithm: sha1WithRSAEncryption
+        Validity
+            Not Before: Sep 30 21:12:19 2000 GMT
+            Not After : Sep 30 14:01:15 2021 GMT
+        Subject: O=Digital Signature Trust Co., CN=DST Root CA X3
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Subject Key Identifier: 
+                C4:A7:B1:A4:7B:2C:71:FA:DB:E1:4B:90:75:FF:C4:15:60:85:89:10
+SHA1 Fingerprint=DA:C9:02:4F:54:D8:F6:DF:94:93:5F:B1:73:26:38:CA:6A:D7:7C:13
+SHA256 Fingerprint=06:87:26:03:31:A7:24:03:D9:09:F1:05:E6:9B:CF:0D:32:E1:BD:24:93:FF:C6:D9:20:6D:11:BC:D6:77:07:39
+-----BEGIN CERTIFICATE-----
+MIIDSjCCAjKgAwIBAgIQRK+wgNajJ7qJMDmGLvhAazANBgkqhkiG9w0BAQUFADA/
+MSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT
+DkRTVCBSb290IENBIFgzMB4XDTAwMDkzMDIxMTIxOVoXDTIxMDkzMDE0MDExNVow
+PzEkMCIGA1UEChMbRGlnaXRhbCBTaWduYXR1cmUgVHJ1c3QgQ28uMRcwFQYDVQQD
+Ew5EU1QgUm9vdCBDQSBYMzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+AN+v6ZdQCINXtMxiZfaQguzH0yxrMMpb7NnDfcdAwRgUi+DoM3ZJKuM/IUmTrE4O
+rz5Iy2Xu/NMhD2XSKtkyj4zl93ewEnu1lcCJo6m67XMuegwGMoOifooUMM0RoOEq
+OLl5CjH9UL2AZd+3UWODyOKIYepLYYHsUmu5ouJLGiifSKOeDNoJjj4XLh7dIN9b
+xiqKqy69cK3FCxolkHRyxXtqqzTWMIn/5WgTe1QLyNau7Fqckh49ZLOMxt+/yUFw
+7BZy1SbsOFU5Q9D8/RhcQPGX69Wam40dutolucbY38EVAjqr2m7xPi71XAicPNaD
+aeQQmxkqtilX4+U9m5/wAl0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNV
+HQ8BAf8EBAMCAQYwHQYDVR0OBBYEFMSnsaR7LHH62+FLkHX/xBVghYkQMA0GCSqG
+SIb3DQEBBQUAA4IBAQCjGiybFwBcqR7uKGY3Or+Dxz9LwwmglSBd49lZRNI+DT69
+ikugdB/OEIKcdBodfpga3csTS7MgROSR6cz8faXbauX+5v3gTt23ADq1cEmv8uXr
+AvHRAosZy5Q6XkjEGB5YGV8eAlrwDPGxrancWYaLbumR9YbK+rlmM6pZW87ipxZz
+R8srzJmwN0jP41ZL9c8PDHIyh8bwRLtTcm1D9SZImlJnt1ir/md2cXjbDaJWFBM5
+JDGFoqgCWjBH4d1QB7wCCZAA62RjYJsWvIjJEubSfZGL+T0yjWW06XyxV3bqxbYo
+Ob8VZRzI9neWagqNdwvYkQsEjgfbKbYK7p2CNTUQ
+-----END CERTIFICATE-----
+
+### Internet Security Research Group
+
+=== /C=US/O=Internet Security Research Group/CN=ISRG Root X1
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            82:10:cf:b0:d2:40:e3:59:44:63:e0:bb:63:82:8b:00
+    Signature Algorithm: sha256WithRSAEncryption
+        Validity
+            Not Before: Jun  4 11:04:38 2015 GMT
+            Not After : Jun  4 11:04:38 2035 GMT
+        Subject: C=US, O=Internet Security Research Group, CN=ISRG Root X1
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Subject Key Identifier: 
+                79:B4:59:E6:7B:B6:E5:E4:01:73:80:08:88:C8:1A:58:F6:E9:9B:6E
+SHA1 Fingerprint=CA:BD:2A:79:A1:07:6A:31:F2:1D:25:36:35:CB:03:9D:43:29:A5:E8
+SHA256 Fingerprint=96:BC:EC:06:26:49:76:F3:74:60:77:9A:CF:28:C5:A7:CF:E8:A3:C0:AA:E1:1A:8F:FC:EE:05:C0:BD:DF:08:C6
+-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+-----END CERTIFICATE-----


### PR DESCRIPTION
As discussed in #328, this adds an integration test for the Let's Encrypt long chain handling on OTP 23.3 (prior to 23.3.4.5) and 24.0 (prior to 24.0.4).