### PR TITLE
Silence certificate path validation warnings

### DIFF
--- a/test/mint/core/transport/ssl_test.exs
+++ b/test/mint/core/transport/ssl_test.exs
@@ -165,6 +165,8 @@ defmodule Mint.Core.Transport.SSLTest do
   end
 
   describe "controlling_process/2" do
+    @describetag :capture_log
+
     setup do
       parent = self()
       ref = make_ref()

--- a/test/mint/http1/integration_test.exs
+++ b/test/mint/http1/integration_test.exs
@@ -187,6 +187,7 @@ defmodule Mint.HTTP1.IntegrationTest do
   end
 
   describe "badssl.com" do
+    @tag :capture_log
     test "SSL with bad certificate" do
       assert {:error, %TransportError{reason: reason}} =
                HTTP1.connect(:https, "untrusted-root.badssl.com", 443,
@@ -203,6 +204,7 @@ defmodule Mint.HTTP1.IntegrationTest do
                )
     end
 
+    @tag :capture_log
     test "SSL with bad hostname" do
       assert {:error, %TransportError{reason: reason}} =
                HTTP1.connect(:https, "wrong.host.badssl.com", 443,

--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -13,6 +13,8 @@ defmodule Mint.HTTP2Test do
 
   require Mint.HTTP
 
+  @moduletag :capture_log
+
   setup :start_connection
 
   defmacrop assert_recv_frames(frames) when is_list(frames) do

--- a/test/mint/integration_test.exs
+++ b/test/mint/integration_test.exs
@@ -76,6 +76,7 @@ defmodule Mint.IntegrationTest do
   describe "ssl certificate verification" do
     @describetag :integration
 
+    @tag :capture_log
     test "bad certificate - badssl.com" do
       assert {:error, %TransportError{reason: reason}} =
                HTTP.connect(
@@ -98,6 +99,7 @@ defmodule Mint.IntegrationTest do
                )
     end
 
+    @tag :capture_log
     test "bad hostname - badssl.com" do
       assert {:error, %TransportError{reason: reason}} =
                HTTP.connect(

--- a/test/mint/unix_socket_test.exs
+++ b/test/mint/unix_socket_test.exs
@@ -24,6 +24,7 @@ defmodule Mint.UnitSocketTest do
     assert responses == [{:status, ref, 200}]
   end
 
+  @tag :capture_log
   test "starting an https connection to a unix domain socket works" do
     {:ok, address, server_ref} = TestSocketServer.start(ssl: true)
 


### PR DESCRIPTION
```
[warning] Description: 'Authenticity is not established by certificate path validation'
     Reason: 'Option {verify, verify_peer} and cacertfile/cacerts is missing'
```

See: https://github.com/erlang/otp/issues/5352.