### PR TITLE
Use `import Bitwise` instead of `use Bitwise`

### DIFF
--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -125,8 +125,6 @@ defmodule Mint.HTTP2 do
   is enabled.
   """
 
-  use Bitwise, skip_operators: true
-
   import Mint.Core.Util
   import Mint.HTTP2.Frame, except: [encode: 1, decode_next: 1]
 

--- a/lib/mint/http2/frame.ex
+++ b/lib/mint/http2/frame.ex
@@ -1,8 +1,7 @@
 defmodule Mint.HTTP2.Frame do
   @moduledoc false
 
-  use Bitwise, skip_operators: true
-
+  import Bitwise, only: [band: 2, bor: 2]
   import Record
 
   shared_stream = [:stream_id, {:flags, 0x00}]

--- a/test/mint/http2/frame_test.exs
+++ b/test/mint/http2/frame_test.exs
@@ -2,7 +2,7 @@ defmodule Mint.HTTP2.FrameTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
-  use Bitwise, skip_operators: true
+  import Bitwise, only: [bor: 2]
 
   import Mint.HTTP2.Frame, except: [decode_next: 1, encode_raw: 4]
 


### PR DESCRIPTION
Fixes the deprecation warnings for Elixir >= 1.14.
Also removed unused `use Bitwise` in `http2.ex`.