### PR TITLE
Correct `get_window_size/2` docs

### DIFF
--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -735,17 +735,17 @@ defmodule Mint.HTTP2 do
 
   On the connection:
 
-      HTTP.get_window_size(conn, :connection)
+      HTTP2.get_window_size(conn, :connection)
       #=> 65_536
 
   On a single streamed request:
 
       {:ok, conn, request_ref} = HTTP2.request(conn, "GET", "/", [], :stream)
-      HTTP.get_window_size(conn, {:request_ref, request_ref})
+      HTTP2.get_window_size(conn, {:request, request_ref})
       #=> 65_536
 
       {:ok, conn} = HTTP2.stream_request_body(conn, request_ref, "hello")
-      HTTP.get_window_size(conn, {:request_ref, request_ref})
+      HTTP2.get_window_size(conn, {:request, request_ref})
       #=> 65_531
 
   """


### PR DESCRIPTION
This PR corrects the documentation for the `HTTP2.get_window_size/2` function.

This function only exists in the `HTTP2` module, and pattern matches on the `:request` atom instead of `:request_ref`

https://github.com/elixir-mint/mint/blob/e7199d1163e5a8a1b0001cacc93063e866dbaa35/lib/mint/http2.ex#L759-L768