### PR TITLE
Properly close socket on erroneous connection

### DIFF
--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -2028,10 +2028,11 @@ defmodule Mint.HTTP2 do
     frame =
       goaway(stream_id: 0, last_stream_id: 2, error_code: error_code, debug_data: debug_data)
 
-    conn = send!(conn, Frame.encode(frame))
+    # try send goaway frame and close connection
+    _ = conn.transport.send(conn.socket, Frame.encode(frame))
     _ = conn.transport.close(conn.socket)
-    conn = put_in(conn.state, :closed)
-    throw({:mint, conn, wrap_error({error_code, debug_data})})
+
+    throw({:mint, %{conn | state: :closed}, wrap_error({error_code, debug_data})})
   end
 
   defp close_stream!(conn, stream_id, error_code) do

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -2028,7 +2028,9 @@ defmodule Mint.HTTP2 do
     frame =
       goaway(stream_id: 0, last_stream_id: 2, error_code: error_code, debug_data: debug_data)
 
-    # try send goaway frame and close connection
+    # Try to send the GOAWAY frame and close connection.
+    # If the frame fails to send, we still want to set the close
+    # the socket, set the connection state to :closed, and return an error.
     _ = conn.transport.send(conn.socket, Frame.encode(frame))
     _ = conn.transport.close(conn.socket)
 

--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -391,6 +391,35 @@ defmodule Mint.HTTP2Test do
         conn
       end)
     end
+
+    test "close/1 properly closes socket on active connection", %{conn: conn} do
+      # Check socket status, before close it should be :ok
+      socket = HTTP2.get_socket(conn)
+      assert {:ok, _} = :ssl.getstat(socket)
+
+      # Closed successfully
+      assert {:ok, conn} = HTTP2.close(conn)
+      refute HTTP2.open?(conn)
+
+      # Check socket status again, after close it should be :error
+      assert {:error, _} = :ssl.getstat(socket)
+    end
+
+    test "close/1 properly closes socket on errornous connection", %{conn: conn} do
+      # force the transport to one that always times out on send
+      conn = %{conn | transport: Mint.HTTP2.TestTransportSendTimeout}
+
+      # Check socket status, before close it should be :ok
+      socket = HTTP2.get_socket(conn)
+      assert {:ok, _} = :ssl.getstat(socket)
+
+      # Closed successfully
+      assert {:ok, conn} = HTTP2.close(conn)
+      refute HTTP2.open?(conn)
+
+      # Check socket status again, after close it should be :error
+      assert {:error, _} = :ssl.getstat(socket)
+    end
   end
 
   describe "client errors" do

--- a/test/support/mint/http2/test_helpers.ex
+++ b/test/support/mint/http2/test_helpers.ex
@@ -50,4 +50,11 @@ defmodule Mint.HTTP2.TestHelpers do
   def maybe_done(conn, [], acc) do
     receive_stream(conn, acc)
   end
+
+  @doc """
+  Extracts port from ssl socket
+  """
+  def extract_port({:sslsocket, {_, port, _, _}, _} = _ssl_socket) do
+    port
+  end
 end


### PR DESCRIPTION
Fix #365