### PR TITLE
Skip calling pkix_decode_cert if the certs are already of tuple types

### DIFF
--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -607,7 +607,10 @@ defmodule Mint.Core.Transport.SSL do
   end
 
   defp decode_cacerts(certs) do
-    Enum.map(certs, &:public_key.pkix_decode_cert(&1, :plain))
+    Enum.map(certs, fn
+      cert when is_binary(cert) ->  :public_key.pkix_decode_cert(cert, :plain)
+      {:cert, _, otp_certificate} -> otp_certificate
+    end)
   end
 
   def partial_chain(cacerts, certs) do

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -608,7 +608,7 @@ defmodule Mint.Core.Transport.SSL do
 
   defp decode_cacerts(certs) do
     Enum.map(certs, fn
-      cert when is_binary(cert) ->  :public_key.pkix_decode_cert(cert, :plain)
+      cert when is_binary(cert) -> :public_key.pkix_decode_cert(cert, :plain)
       {:cert, _, otp_certificate} -> otp_certificate
     end)
   end

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -91,11 +91,10 @@ defmodule Mint.HTTP do
   Starting [from OTP
   25](https://www.erlang.org/blog/my-otp-25-highlights/#ca-certificates-can-be-fetched-from-the-os-standard-place),
   you can also load certificates from a file
-  ([`:public_key.cacerts_load/1`](https://www.erlang.org/doc/man/public_key.html#cacerts_load-1))
-  or from the OS
-  ([`:public_key.cacerts_load/0`](https://www.erlang.org/doc/man/public_key.html#cacerts_load-0)).
-  You can then use the certificates with
-  [`:public_key.cacerts_get/0`](https://www.erlang.org/doc/man/public_key.html#cacerts_get-0):
+  ([`:public_key.cacerts_load/1`](https://www.erlang.org/doc/man/public_key.html#cacerts_load-1)).
+  You can also get certificate from the OS trust store using
+  [`:public_key.cacerts_get/0`](https://www.erlang.org/doc/man/public_key.html#cacerts_get-0).
+  If you are using OTP 25+ it is recommended to set this option.
 
       Mint.connect(:https, host, port, transport_opts: [cacerts: :public_key.cacerts_get()])
 
@@ -230,12 +229,16 @@ defmodule Mint.HTTP do
 
     * `:alpn_advertised_protocols` - managed by Mint. Cannot be overridden.
 
-    * `:cacertfile` - if `:verify` is set to `:verify_peer` (the default) and
+    * `:cacerts` - certificates of types `:ssl.client_cacerts()`.
+      If `:verify` is set to `:verify_peer` (the default) and
       no CA trust store is specified using the `:cacertfile` or `:cacerts`
       option, Mint will attempt to use the trust store from the
       [CAStore](https://github.com/elixir-mint/castore) package or raise an
-      exception if this package is not available. Due to caching the
-      `:cacertfile` option is more efficient than `:cacerts`.
+      exception if this package is not available. It is reommended to set this
+      option to `:public_key.cacerts_get()`.
+
+    * `:cacertfile` - path to a file containing PEM-encoded CA certificates.
+      See the `:cacerts` option for the defaults to this value.
 
     * `:ciphers` - defaults to the lists returned by
       `:ssl.filter_cipher_suites(:ssl.cipher_suites(:all, version), [])`


### PR DESCRIPTION
- Resolves https://github.com/elixir-mint/mint/issues/377

- [`:public_key.cacerts_get/0`](https://www.erlang.org/doc/man/public_key.html#cacerts_get-0) returns [`combined_cert`](https://www.erlang.org/doc/man/public_key.html#type-combined_cert) which contains both the undecoded binary and the decoded `#'OTPCertificate'{}`

 - While calling [`:public_key.pkix_decode_cert`](https://www.erlang.org/doc/man/public_key.html#pkix_decode_cert-2) with `:plain` returns `#'Certificate'{}`, both `#'OTPCertificate'{}` and `#'Certificate'{}` share very similar structure ([document](https://www.erlang.org/doc/apps/public_key/public_key_records.html#pkix-certificates)) and they both have `subjectPublicKeyInfo` and `validity`. Since we only depends on those 2 data to verify the certificates, just passing the `#'OTPCertificate'{}` from `:public_key.cacerts_get/0` through should be sufficient