### PR TITLE
Allow 302 status for twitter integration test

### DIFF
--- a/test/mint/http2/integration_test.exs
+++ b/test/mint/http2/integration_test.exs
@@ -183,7 +183,9 @@ defmodule HTTP2.IntegrationTest do
 
       assert {:ok, %HTTP2{} = conn, responses} = receive_stream(conn)
 
-      assert [{:status, ^ref, 200}, {:headers, ^ref, headers} | rest] = responses
+      assert [{:status, ^ref, status}, {:headers, ^ref, headers} | rest] = responses
+      assert status in [200, 302]
+
       assert {_, [{:done, ^ref}]} = Enum.split_while(rest, &match?({:data, ^ref, _}, &1))
 
       assert is_list(headers)


### PR DESCRIPTION
twitter redirects requests to `/` to feed cookie

```
> GET / HTTP/1.1
> Host: twitter.com
> User-Agent: curl/7.86.0
> Accept: */*
> 
< HTTP/1.1 302 Found
< date: Wed, 10 May 2023 22:27:45 GMT
< perf: 7626143928
< vary: Accept
< server: tsa_f
< location: /
< set-cookie: guest_id=DONTHACKME; Max-Age=34214400; Expires=Sun, 09 Jun 2024 22:27:45 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
< content-type: text/plain; charset=utf-8
< x-powered-by: Express
< cache-control: no-cache, no-store, max-age=0
< content-length: 23
< x-transaction-id: 7f46533dbc8f17ff
< strict-transport-security: max-age=631138519
< x-response-time: 110
< x-connection-hash: f8c483d519f1efdc5bbcf97d82c0e5b8d4b7e532dd4fca239b59d9557a586213

```

I suspect we DOSing `httpbin` with CI. 