### PR TITLE
Update Decompression.md - drop deflate, mention zstd

### DIFF
--- a/pages/Decompression.md
+++ b/pages/Decompression.md
@@ -1,8 +1,8 @@
 # Decompression
 
-Many web servers use compression to reduce the size of the payload to speed up delivery to clients, expecting clients to decompress the body of the request. Some of the common compression algorithms used are [gzip], [brotli], [deflate], or no compression at all.
+Many web servers use compression to reduce the size of the payload to speed up delivery to clients, expecting clients to decompress the body of the request. Some of the common compression algorithms used are [gzip], [brotli], [zstd], or no compression at all.
 
-Clients may specify acceptable compression algorithms through the [`accept-encoding`][accept-encoding] request header. It's common for clients to supply one or more values in `accept-encoding`, for example `accept-encoding: gzip, deflate, identity` in the order of preference.
+Clients may specify acceptable compression algorithms through the [`accept-encoding`][accept-encoding] request header. It's common for clients to supply one or more values in `accept-encoding`, for example `accept-encoding: gzip, br` in the order of preference.
 
 Servers will read the `accept-encoding` and `TE` request headers, and respond appropriately indicating which compression is used in the response body through the [`content-encoding`][content-encoding] or [`transfer-encoding`][transfer-encoding] response headers respectively. It's not as common to use multiple compression algorithms, but it is possible: for example, `content-encoding: gzip` or `content-encoding: br, gzip` (meaning it was compressed with `br` first, and then `gzip`).
 
@@ -44,7 +44,7 @@ defp get_content_encoding_header(headers) do
 end
 ```
 
-We use a combination of `Enum.flat_map/3` and `String.split/3` because the values can be comma-separated and spread over multiple headers. Now we should have a list like `["gzip"]`. We reversed the compression algorithms so that we decompress from the last one to the first one. Let's use this in another function that handles the decompression. Thankfully, Erlang ships with built-in support for gzip and deflate algorithms.
+We use a combination of `Enum.flat_map/3` and `String.split/3` because the values can be comma-separated and spread over multiple headers. Now we should have a list like `["gzip"]`. We reversed the compression algorithms so that we decompress from the last one to the first one. Let's use this in another function that handles the decompression. Thankfully, Erlang ships with built-in support for gzip algorithm.
 
 ```elixir
 defp decompress_data(data, algorithms) do
@@ -53,9 +53,6 @@ end
 
 defp decompress_with_algorithm(gzip, data) when gzip in ["gzip", "x-gzip"],
   do: :zlib.gunzip(data)
-
-defp decompress_with_algorithm("deflate", data),
-  do: :zlib.unzip(data)
 
 defp decompress_with_algorithm("identity", data),
   do: data
@@ -87,7 +84,7 @@ Now you can decompress responses! Above is a simple approach to a potentially co
 
 [gzip]: https://tools.ietf.org/html/rfc1952
 [brotli]: https://tools.ietf.org/html/rfc7932
-[deflate]: https://tools.ietf.org/html/rfc1951
+[ztsd]: https://tools.ietf.org/html/rfc8478
 [accept-encoding]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding
 [content-encoding]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
 [transfer-encoding]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding


### PR DESCRIPTION
First of all, we can't use `:zlib.unzip/1` for deflate. If anything, it's `:zlib.uncompress/1`:

```elixir
iex> Req.get!("http://httpbin.org/deflate", raw: true).body |> :zlib.unzip()
** (ErlangError) Erlang error: :data_error
    :zlib.inflate_nif(#Reference<0.3067689971.3529113605.174556>, 8192, 16384, 0)
    :zlib.dequeue_all_chunks_1/3
    :zlib.inflate/3
    :zlib.unzip/1
    iex:3: (file)
iex> Req.get!("http://httpbin.org/deflate", raw: true).body |> :zlib.uncompress()
"{\n  \"deflated\": true, \n  \"headers\": {\n    \"Accept-Encoding\": \"zstd, br, gzip\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"req/0.3.11\", \n    \"X-Amzn-Trace-Id\": \"Root=1-64d6b50d-4c634ab23ae6d5fe3dab6694\"\n  }, \n  \"method\": \"GET\", \n  \"origin\": \"89.73.45.237\"\n}\n"
```

But I don't think it's quite that simple.

Bandit has support for deflate: https://github.com/mtrudel/bandit/blob/1.0.0-pre.11/lib/bandit/compression.ex#L15 but using `:zlib.uncompress/1` there crashes:

```elixir
iex> Bandit.Compression.compress("hello", "deflate", []) |> :zlib.uncompress()
** (ErlangError) Erlang error: :data_error
    (erts 14.0.2) :zlib.inflateEnd_nif(#Reference<0.2420980051.2993029125.66777>)
    (erts 14.0.2) :zlib.uncompress/1
    iex:2: (file)
```

I trust @mtrudel to have followed the RFCs and implemented this correctly. :) So if you want to mention `deflate`, we should follow his implementation, do the opposite.

But, and maybe I'm just burned out with this a bit, I don't think it's worth it. None of the big sites seem to support it. And then there's https://zlib.net/zlib_faq.html#faq39

> What's the difference between the "gzip" and "deflate" HTTP 1.1 encodings?
>
> "gzip" is the gzip format, and "deflate" is the zlib format. They should probably have called the second one "zlib" instead to avoid confusion with the raw deflate compressed data format. While the HTTP 1.1 RFC 2616 correctly points to the zlib specification in RFC 1950 for the "deflate" transfer encoding, there have been reports of servers and browsers that incorrectly produce or expect raw deflate data per the deflate specification in RFC 1951, most notably Microsoft. So even though the "deflate" transfer encoding using the zlib format would be the more efficient approach (and in fact exactly what the zlib format was designed for), using the "gzip" transfer encoding is probably more reliable due to an unfortunate choice of name on the part of the HTTP 1.1 authors.
>
> Bottom line: use the gzip format for HTTP 1.1 encoding.

And then there's this excerpt from [`zlib:deflateInit/6`](https://www.erlang.org/doc/man/zlib#deflateInit-6)

> WindowBits - The base two logarithm of the window size (the size of the history buffer). It is to be in the range 8 through 15. Larger values result in better compression at the expense of memory usage. Defaults to 15 if [deflateInit/2](https://www.erlang.org/doc/man/zlib#deflateInit-2) is used. **A negative WindowBits value suppresses the zlib header (and checksum) from the stream. Notice that the zlib source mentions this only as a undocumented feature.**

Again I think the implementation is correct because I saw setting `-MAX_BITS` in Python or Ruby too.

I had (wrong) support for it in Req and decided to just drop it (https://github.com/wojtekmach/req/commit/e19d89f6c6eb1dd21a373c192f50afa6026fdbac, https://github.com/wojtekmach/req/issues/215) fwiw.