### PR TITLE
Ensure correct SELinux labeling of container files on SELinux enabled systems.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     # and we are not root in the gh action so cannot access them
     user: "${DOCKER_USER}"
     volumes:
-      - "./caddy_storage:/caddy_storage"
-      - "./Caddyfile:/etc/caddy/Caddyfile"
+      - "./caddy_storage:/caddy_storage:z"
+      - "./Caddyfile:/etc/caddy/Caddyfile:z"
     ports:
       - "8443:8443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     # and we are not root in the gh action so cannot access them
     user: "${DOCKER_USER}"
     volumes:
+      # The :z mount option solves issues with SELinux.
+      # See https://github.com/elixir-mint/mint/pull/406. 
       - "./caddy_storage:/caddy_storage:z"
       - "./Caddyfile:/etc/caddy/Caddyfile:z"
     ports:


### PR DESCRIPTION
While attempting to add a naive "Happy Eyeballs" option for testing and experimentation, I encountered a "permission denied" error when running the docker-compose command. It was not immediately apparent that SELinux was the cause of the issue, making it challenging to identify the root cause.

To resolve this issue, this commit adds the `:z` mount option, which ensures SELinux compatibility by addressing the permission issues caused by SELinux when the Caddyfile is mounted without the appropriate label.

It's important to note that this change should only affect systems with SELinux enabled.