### PR TITLE
Add `match_fun` clause to deal with ip addresses in TLS handshake

### DIFF
--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -509,7 +509,11 @@ defmodule Mint.Core.Transport.SSL do
     end
   end
 
-  # In case the hostname is an IP address:
+  # Workaround for a bug that was fixed in OTP 27:
+  # Before OTP 27 when connecting to an IP address and the server offers a
+  # certificate with its IP address in the "subject alternate names" extension,
+  # the TLS handshake fails with a `{:bad_cert, :hostname_check_failed}`.
+  # This clause can be removed once we depend on OTP 27+.
   defp match_fun({:dns_id, hostname}, {:iPAddress, ip}) do
     with {:ok, ip_tuple} <- :inet.parse_address(hostname),
          ^ip <- Tuple.to_list(ip_tuple) do

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -509,6 +509,16 @@ defmodule Mint.Core.Transport.SSL do
     end
   end
 
+  # In case the hostname is an IP address:
+  defp match_fun({:dns_id, hostname}, {:iPAddress, ip}) do
+    with {:ok, ip_tuple} <- :inet.parse_address(hostname),
+         ^ip <- Tuple.to_list(ip_tuple) do
+      true
+    else
+      _ -> :default
+    end
+  end
+
   defp match_fun(_reference, _presented), do: :default
 
   defp domain_without_host([]), do: []

--- a/test/mint/core/transport/ssl_test.exs
+++ b/test/mint/core/transport/ssl_test.exs
@@ -148,6 +148,10 @@ defmodule Mint.Core.Transport.SSLTest do
       refute :mint_shims.pkix_verify_hostname(cert, ip: {1, 2, 3, 4})
       refute :mint_shims.pkix_verify_hostname(cert, ip: {10, 11, 12, 13})
     end
+
+    test "custom match fun for IP addresses as hostname", %{cert: cert} do
+      assert {:valid, _} = SSL.verify_fun(cert, :valid_peer, dns_id: ~c"10.67.16.75")
+    end
   end
 
   # Certificate chain rooted in an expired root CA, and CA store containing


### PR DESCRIPTION
Hey there

I think there's a bug in the OTP so I've opened an issue there: https://github.com/erlang/otp/issues/7968. I'm not sure they see it as a bug and how long it may take to fix this. Maybe it is not a bug for Erlang after all but it sure is for the Elixir world. And Mint is one place where it could be fixed. There's also a discussion on the [Elixir Forum](https://elixirforum.com/t/flame-k8s-backend-a-flame-backend-for-kubernetes/60346/3) about this. But let me quickly state the problem here, too.

### Problem

The problem occurs when trying connect to an IP address over SSL where the server offers a certificate with its IP address in the "subject alternate names" extension. This is often the case when connecting to a Kubernetes API Server from within Kubernetes (hence the discussion on the `flame_k8s_backend` thread).

The TLS handshake should succeed. However, due to a mismatch in types (Erlang expects IP addresses to be in the form `{127, 0, 0, 1}`, Mint sends `~c"127.0.0.1"`), We get a `{:bad_cert, :hostname_check_failed}`. 

### How to reproduce

You can generate a rootCA and a certificate using `openssl` (don't forget to add the IP: `-addext "subjectAltName = IP:127.0.0.1"`) and run  `openssl s_server -accept 4443 -cert serverCert.pem -key serverKey.pem -CAfile rootCACert.pem -WWW`. 

Then the following code shows the problem:

```elixir
ca_cert =
  "/path/to/rootCACert.pem"
  |> File.read!()
  |> :public_key.pem_decode()
  |> Enum.find_value(fn
    {:Certificate, data, _} -> data
    _ -> raise "Certificate data is missing"
  end)

Mint.HTTP.connect(:https, "127.0.0.1", 4443, transport_opts: [cacerts: [ca_cert]])
```

### Solving the Problem

I guess there's more than one way to deal with this. 

1. This PR (using a `match_fun` to validate the presented address)
1. Convert IP addresses to [`t:inet:ip_address()`](https://www.erlang.org/doc/man/inet#type-ip_address) when passing them to `:ssl.connect()`
1. Let Erlang deal with the problem
1. Let the user or higher level libs deal with the problem

All are valid options. But I feel like this is a problem that needs to be fixed in one of the lower abstraction levels because it leads users to set `verify: :verify_none` where it's not needed. 
In any case, mostly I wanted to let you guys know about the problem. Feel free to reject the PR if you find it should be fixed elsewhere. Or merge it to fix it here until it's fixed in the OTP...