### PR TITLE
Optimize HTTP/2 request creation

### DIFF
--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -1365,7 +1365,7 @@ defmodule Mint.HTTP2 do
   end
 
   defp add_pseudo_headers(headers, conn, method, path) do
-    if String.upcase(method) == "CONNECT" do
+    if is_method?(method, ~c"CONNECT") do
       [
         {":method", method},
         {":authority", conn.authority}
@@ -1381,6 +1381,20 @@ defmodule Mint.HTTP2 do
       ]
     end
   end
+
+  @spec is_method?(proposed :: binary(), method :: charlist()) :: boolean()
+  defp is_method?(<<>>, []), do: true
+
+  defp is_method?(<<char, rest_bin::binary>>, [char | rest_list]) do
+    is_method?(rest_bin, rest_list)
+  end
+
+  defp is_method?(<<lower_char, rest_bin::binary>>, [char | rest_list])
+       when lower_char >= ?a and lower_char <= ?z and lower_char - 32 == char do
+    is_method?(rest_bin, rest_list)
+  end
+
+  defp is_method?(_proposed, _method), do: false
 
   defp sort_pseudo_headers_to_front(headers) do
     Enum.sort_by(headers, fn {key, _value} ->


### PR DESCRIPTION
There is some low-hanging fruit to improve the time it takes to open a new request with HTTP/2 by avoiding `URI.default_port/1` and `String.upcase/1` calls.

With some very un-scientific `:timer.tc/1` benchmarking I see these changes reduce the time it takes to complete a `Mint.HTTP2.request/5` call (passing `:stream` as the data argument) from 12.8ms to 2.5ms.