### PR TITLE
Replace Util.downcase_ascii with String.downcase(&1, :ascii)

### DIFF
--- a/lib/mint/core/util.ex
+++ b/lib/mint/core/util.ex
@@ -107,17 +107,6 @@ defmodule Mint.Core.Util do
     end
   end
 
-  # Lowercases an ASCII string more efficiently than
-  # String.downcase/1.
-  @spec downcase_ascii(String.t()) :: String.t()
-  def downcase_ascii(string) do
-    for <<char <- string>>, do: <<downcase_ascii_char(char)>>, into: ""
-  end
-
-  @spec downcase_ascii_char(byte()) :: byte()
-  def downcase_ascii_char(char) when char in ?A..?Z, do: char + 32
-  def downcase_ascii_char(char) when char in 0..127, do: char
-
   # If the buffer is empty, reusing the incoming data saves
   # a potentially large allocation of memory.
   # This should be fixed in a subsequent OTP release.

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -973,7 +973,7 @@ defmodule Mint.HTTP1 do
   end
 
   defp lower_header_keys(headers) do
-    for {name, value} <- headers, do: {Util.downcase_ascii(name), value}
+    for {name, value} <- headers, do: {String.downcase(name, :ascii), value}
   end
 
   defp add_default_headers(headers, conn) do

--- a/lib/mint/http1/parse.ex
+++ b/lib/mint/http1/parse.ex
@@ -55,7 +55,7 @@ defmodule Mint.HTTP1.Parse do
   defp token_list_downcase(rest, acc), do: token_downcase(rest, _token_acc = <<>>, acc)
 
   defp token_downcase(<<char, rest::binary>>, token_acc, acc) when is_tchar(char),
-    do: token_downcase(rest, <<token_acc::binary, Util.downcase_ascii_char(char)>>, acc)
+    do: token_downcase(rest, <<token_acc::binary, downcase_ascii_char(char)>>, acc)
 
   defp token_downcase(rest, token_acc, acc), do: token_list_sep_downcase(rest, [token_acc | acc])
 
@@ -68,4 +68,7 @@ defmodule Mint.HTTP1.Parse do
     do: token_list_downcase(rest, acc)
 
   defp token_list_sep_downcase(_rest, _acc), do: :error
+
+  defp downcase_ascii_char(char) when char in ?A..?Z, do: char + 32
+  defp downcase_ascii_char(char) when char in 0..127, do: char
 end

--- a/lib/mint/http1/response.ex
+++ b/lib/mint/http1/response.ex
@@ -38,6 +38,11 @@ defmodule Mint.HTTP1.Response do
     end
   end
 
-  defp header_name(atom) when is_atom(atom), do: atom |> Atom.to_string() |> Util.downcase_ascii()
-  defp header_name(binary) when is_binary(binary), do: Util.downcase_ascii(binary)
+  defp header_name(atom) when is_atom(atom) do
+    atom
+    |> Atom.to_string()
+    |> String.downcase(:ascii)
+  end
+
+  defp header_name(binary) when is_binary(binary), do: String.downcase(binary, :ascii)
 end

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -1335,7 +1335,7 @@ defmodule Mint.HTTP2 do
   end
 
   defp downcase_header_names(headers) do
-    for {name, value} <- headers, do: {Util.downcase_ascii(name), value}
+    for {name, value} <- headers, do: {String.downcase(name, :ascii), value}
   end
 
   defp add_default_headers(headers, body) do
@@ -1730,7 +1730,7 @@ defmodule Mint.HTTP2 do
 
   defp join_cookie_headers(headers) do
     # If we have 0 or 1 Cookie headers, we just use the old list of headers.
-    case Enum.split_with(headers, fn {name, _value} -> Util.downcase_ascii(name) == "cookie" end) do
+    case Enum.split_with(headers, fn {name, _value} -> String.downcase(name, :ascii) == "cookie" end) do
       {[], _headers} ->
         headers
 


### PR DESCRIPTION
## Summary

This PR removes calls to Mint's original `downcase_ascii/1` which was found to be slower than Elixir's stock downcase with the `:ascii` option.

## Related

Closes #420 

## Notes

I unrolled HTTP1.Parser.header_name/1's atom case for clarity, as inline pipes on the same line can be hard to read, I hope this is okay.