### PR TITLE
Default to using Erlang certificates store

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -2,5 +2,6 @@
   {"lib/mint/tunnel_proxy.ex", :call_with_opaque, 49},
   {"lib/mint/http1.ex", :improper_list_constr},
   ~r{test/support},
-  ~r{Function ExUnit.Assertion.* does not exist}
+  ~r{Function ExUnit.Assertion.* does not exist},
+  ~r{Call to missing or private function :public_key.cacerts_get/0}
 ]

--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@
 
 ## Installation
 
-To install Mint, add it to your `mix.exs` file. Unless you're using your own SSL certificate store, also add the [CAStore][castore] library to your dependencies.
+To install Mint, add it to your `mix.exs` file:
 
 ```elixir
 defp deps do
   [
-    {:castore, "~> 1.0"},
     {:mint, "~> 1.0"}
   ]
 end
@@ -83,7 +82,7 @@ For more information, see [the documentation][documentation].
 
 ### SSL certificates
 
-When using SSL, you can pass in your own CA certificate store or use one provided by Mint. Mint doesn't ship with the certificate store itself, but it has an optional dependency on [CAStore][castore], which provides an up-to-date certificate store. If you don't want to use your own certificate store, just add `:castore` to your dependencies.
+When using SSL, you can pass in your own CA certificate store. If one is not provided, Mint will use the one in your system, as long as you are using Erlang/OTP 25+. If none of these conditions are true, just add `:castore` to your dependencies.
 
 ```elixir
 defp deps do

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -572,8 +572,13 @@ defmodule Mint.Core.Transport.SSL do
     if Keyword.has_key?(opts, :cacertfile) or Keyword.has_key?(opts, :cacerts) do
       opts
     else
-      raise_on_missing_castore!()
-      Keyword.put(opts, :cacertfile, CAStore.file_path())
+      try do
+        Keyword.put(opts, :cacerts, :public_key.cacerts_get())
+      rescue
+        _ ->
+          raise_on_missing_castore!()
+          Keyword.put(opts, :cacertfile, CAStore.file_path())
+      end
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -18,6 +18,7 @@ defmodule Mint.MixProject do
         exclude: [
           :persistent_term,
           {:ssl, :cipher_suites, 1},
+          {:public_key, :cacerts_get, 0},
           CAStore
         ]
       ],


### PR DESCRIPTION
The OTP team no longer supports Erlang versions earlier than 25+, so we can assuming that `:public_key.cacerts_get/0` is available and only fallback to `CAStore` if not.

This also solves a bug in that Req/Finch/Mint do not work inside escripts by default (because inside an escript you cannot access the priv dir of an application).