### PR TITLE
Fix incorrect CI badge which still point to Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mint 🌱
 
-[![Build status badge](https://travis-ci.org/elixir-mint/mint.svg?branch=master)](https://travis-ci.org/elixir-mint/mint)
+[![CI badge](https://github.com/elixir-mint/mint/actions/workflows/main.yml/badge.svg)](https://github.com/elixir-mint/mint/actions/workflows/main.yml)
 [![Documentation badge](https://img.shields.io/badge/Documentation-ff69b4)][documentation]
 [![Hex.pm badge](https://img.shields.io/badge/Package%20on%20hex.pm-informational)](https://hex.pm/packages/mint)
 [![Coverage status badge](https://coveralls.io/repos/github/elixir-mint/mint/badge.svg?branch=main)](https://coveralls.io/github/elixir-mint/mint?branch=main)


### PR DESCRIPTION
This should switch the CI badge GitHub badge.