### PR TITLE
Fix cannot build Docker images using Podman Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,12 @@ services:
       - "8889:8888"
 
   httpbin:
-    image: kennethreitz/httpbin:latest
+    image: docker.io/kennethreitz/httpbin:latest
     ports:
       - "8080:80"
 
   caddyhttpbin:
-    image: caddy:2.6.4-alpine
+    image: docker.io/caddy:2.8.4-alpine
     # In GitHub Actions we want to access the files created
     # by Caddy. However, in Linux these end up being owned by root
     # because the container by default runs using the root user

--- a/test/docker/tinyproxy-auth/Dockerfile
+++ b/test/docker/tinyproxy-auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM docker.io/alpine:3.20.1
 
 RUN apk add --no-cache \
 	tinyproxy

--- a/test/docker/tinyproxy/Dockerfile
+++ b/test/docker/tinyproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM docker.io/alpine:3.20.1
 
 RUN apk add --no-cache \
 	tinyproxy


### PR DESCRIPTION
This PR resolves the following error when using `podman-compose`:

    Error: short-name "caddy:2.6.4-alpine" did not resolve to an alias and
    no unqualified-search registries are defined in
    "/etc/containers/registries.conf"

We also bump the Docker image for Caddy and Alpine Linux.