### PR TITLE
Fix http1 integration tests missing :requires_internet_connection tag

### DIFF
--- a/test/mint/http1/integration_test.exs
+++ b/test/mint/http1/integration_test.exs
@@ -5,6 +5,8 @@ defmodule Mint.HTTP1.IntegrationTest do
 
   alias Mint.{TransportError, HTTP1, HttpBin}
 
+  @moduletag :requires_internet_connection
+
   describe "local httpbin" do
     test "200 response" do
       assert {:ok, conn} = HTTP1.connect(:http, "localhost", 8080)


### PR DESCRIPTION
This should resolve the errors when excluding test with :requires_internet_connection tag for http1 tests using the following command.

    mix test --exclude requires_internet_connection