### PR TITLE
Add generic :custom_error case to humanize_error_code.

### DIFF
--- a/lib/mint/http2/frame.ex
+++ b/lib/mint/http2/frame.ex
@@ -474,4 +474,5 @@ defmodule Mint.HTTP2.Frame do
   end
 
   defp humanize_error_code(code), do: {:custom_error, code}
+  defp dehumanize_error_code({:custom_error, code}), do: code
 end

--- a/lib/mint/http2/frame.ex
+++ b/lib/mint/http2/frame.ex
@@ -472,4 +472,6 @@ defmodule Mint.HTTP2.Frame do
     defp humanize_error_code(unquote(code)), do: unquote(human_code)
     defp dehumanize_error_code(unquote(human_code)), do: unquote(code)
   end
+
+  defp humanize_error_code(code), do: {:custom_error, code}
 end

--- a/test/mint/http2/frame_test.exs
+++ b/test/mint/http2/frame_test.exs
@@ -294,7 +294,10 @@ defmodule Mint.HTTP2.FrameTest do
       :connect_error,
       :enhance_your_calm,
       :inadequate_security,
-      :http_1_1_required
+      :http_1_1_required,
+      {:custom_error, 0x11},
+      {:custom_error, 0xFF},
+      {:custom_error, 70007}
     ])
   end
 end


### PR DESCRIPTION
Sometimes webservers respond with custom error codes which causes a FunctionClauseError in the humanize_error_code function. This change adds a generic case of the function that handles those cases.


Closes https://github.com/elixir-mint/mint/issues/437.