### PR TITLE
Add Mint.HTTP.recv_response/3

### DIFF
--- a/lib/mint/core/util.ex
+++ b/lib/mint/core/util.ex
@@ -3,6 +3,9 @@ defmodule Mint.Core.Util do
 
   alias Mint.Types
 
+  defguard is_timeout(timeout)
+           when (is_integer(timeout) and timeout >= 0) or timeout == :infinity
+
   @spec hostname(keyword(), String.t()) :: String.t()
   def hostname(opts, address) when is_list(opts) do
     case Keyword.fetch(opts, :hostname) do

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -900,6 +900,11 @@ defmodule Mint.HTTP do
       Contrary to `recv/3`, this function does not return partial responses on errors. Use
       `recv/3` for full control.
 
+  > #### Error {: .error}
+  >
+  > This function can only be used for one-off requests. If there is another concurrent request,
+  > started by `request/5`, it will crash.
+
   ## Options
 
     * `:timeout` - the maximum amount of time in milliseconds waiting to receive the response.
@@ -979,8 +984,9 @@ defmodule Mint.HTTP do
   end
 
   # Ignore entries from other requests.
-  defp recv_response([_entry | rest], acc, conn, ref, timeout) do
-    recv_response(rest, acc, conn, ref, timeout)
+  defp recv_response([entry | _rest], _acc, _conn, _ref, _timeout) when is_tuple(entry) do
+    ref = elem(entry, 1)
+    raise "received unexpected response from request #{inspect(ref)}"
   end
 
   defp recv_response([], acc, conn, ref, timeout) do

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -903,6 +903,9 @@ defmodule Mint.HTTP do
       Contrary to `recv/3`, this function does not return partial responses on errors. Use
       `recv/3` for full control.
 
+  This function only handles responses for the given `request_ref`. Do not use it when making
+  concurrent requests as responses other than for `request_ref` are ignored.
+
   ## Examples
 
       iex> {:ok, conn} = Mint.HTTP.connect(:https, "httpbin.org", 443, mode: :passive)
@@ -922,9 +925,9 @@ defmodule Mint.HTTP do
                headers: [{binary(), binary()}],
                body: binary()
              }
-  def recv_response(conn, ref, timeout)
-      when is_reference(ref) and Util.is_timeout(timeout) do
-    recv_response([], {nil, [], ""}, conn, ref, timeout)
+  def recv_response(conn, request_ref, timeout)
+      when is_reference(request_ref) and Util.is_timeout(timeout) do
+    recv_response([], {nil, [], ""}, conn, request_ref, timeout)
   end
 
   defp recv_response(

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -939,7 +939,7 @@ defmodule Mint.HTTP do
                body: binary()
              }
   def request_and_response(conn, method, path, headers, body, options \\ []) do
-    options = Keyword.validate!(options, timeout: :infinity)
+    options = keyword_validate!(options, timeout: :infinity)
 
     with {:ok, conn, ref} <- request(conn, method, path, headers, body) do
       recv_response(conn, ref, options[:timeout])
@@ -1006,6 +1006,13 @@ defmodule Mint.HTTP do
       {:error, conn, reason, _responses} ->
         {:error, conn, reason}
     end
+  end
+
+  # TODO: Remove when we require Elixir v1.13
+  if Version.match?(System.version(), ">= 1.13.0") do
+    defp keyword_validate!(keyword, values), do: Keyword.validate!(keyword, values)
+  else
+    defp keyword_validate!(keyword, _values), do: keyword
   end
 
   @doc """

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -900,6 +900,9 @@ defmodule Mint.HTTP do
       as well. An error when sending a request **does not** necessarily mean that the connection
       is closed. Use `open?/1` to verify that the connection is open.
 
+      Contrary to `recv/3`, this function does not return partial responses on errors. Use
+      `recv/3` for full control.
+
   ## Examples
 
       iex> {:ok, conn} = Mint.HTTP.connect(:https, "httpbin.org", 443, mode: :passive)

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -965,15 +965,19 @@ defmodule Mint.HTTP do
   defp recv_response([], acc, conn, ref, timeout) do
     start_time = System.monotonic_time(:millisecond)
 
-    with {:ok, conn, entries} <- recv(conn, 0, timeout) do
-      timeout =
-        if is_integer(timeout) do
-          timeout - System.monotonic_time(:millisecond) - start_time
-        else
-          timeout
-        end
+    case recv(conn, 0, timeout) do
+      {:ok, conn, entries} ->
+        timeout =
+          if is_integer(timeout) do
+            timeout - System.monotonic_time(:millisecond) - start_time
+          else
+            timeout
+          end
 
-      recv_response(entries, acc, conn, ref, timeout)
+        recv_response(entries, acc, conn, ref, timeout)
+
+      {:error, conn, reason, _responses} ->
+        {:error, conn, reason}
     end
   end
 

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -922,6 +922,7 @@ defmodule Mint.HTTP do
       }
       iex> Mint.HTTP.open?(conn)
       true
+
   """
   @spec request_and_response(
           t(),
@@ -934,8 +935,8 @@ defmodule Mint.HTTP do
           {:ok, t(), response}
           | {:error, t(), Types.error()}
         when response: %{
-               status: non_neg_integer(),
-               headers: [{binary(), binary()}],
+               status: Types.status(),
+               headers: Types.headers(),
                body: binary()
              }
   def request_and_response(conn, method, path, headers, body, options \\ []) do
@@ -1009,7 +1010,7 @@ defmodule Mint.HTTP do
   end
 
   # TODO: Remove when we require Elixir v1.13
-  if Version.match?(System.version(), ">= 1.13.0") do
+  if function_exported?(Keyword, :validate!, 2) do
     defp keyword_validate!(keyword, values), do: Keyword.validate!(keyword, values)
   else
     defp keyword_validate!(keyword, _values), do: keyword

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -530,67 +530,6 @@ defmodule Mint.HTTP1 do
   end
 
   @doc """
-  TODO
-
-  ## Examples
-
-      iex> {:ok, conn} = Mint.HTTP1.connect(:https, "httpbin.org", 443, mode: :passive)
-      iex> {:ok, conn, ref} = Mint.HTTP1.request(conn, "GET", "/status/user-agent", [], nil)
-      iex> {:ok, _conn, response} = Mint.HTTP1.recv_response(conn, ref, 5000)
-      iex> response
-      %{
-        status: 201,
-        headers: [
-          {"date", ...},
-          ...
-        ],
-        body: "{\\n  \\"user-agent\\": \\"mint/1.6.2\\"\\n}\\n"
-      }
-  """
-  def recv_response(conn, ref, timeout) do
-    recv_response([], %{status: nil, headers: [], body: ""}, conn, ref, timeout)
-  end
-
-  defp recv_response([{:status, ref, status} | rest], acc, conn, ref, timeout) do
-    acc = put_in(acc.status, status)
-    recv_response(rest, acc, conn, ref, timeout)
-  end
-
-  defp recv_response([{:headers, ref, headers} | rest], acc, conn, ref, timeout) do
-    acc = update_in(acc.headers, &(&1 ++ headers))
-    recv_response(rest, acc, conn, ref, timeout)
-  end
-
-  defp recv_response([{:data, ref, data} | rest], acc, conn, ref, timeout) do
-    acc = update_in(acc.body, &(&1 <> data))
-    recv_response(rest, acc, conn, ref, timeout)
-  end
-
-  defp recv_response([{:done, ref} | _], acc, conn, ref, _timeout) do
-    {:ok, conn, acc}
-  end
-
-  # Ignore entries from other requests.
-  defp recv_response([_entry | rest], acc, conn, ref, timeout) do
-    recv_response(rest, acc, conn, ref, timeout)
-  end
-
-  defp recv_response([], acc, conn, ref, timeout) do
-    start_time = System.monotonic_time(:millisecond)
-
-    with {:ok, conn, entries} <- recv(conn, 0, timeout) do
-      timeout =
-        if is_integer(timeout) do
-          timeout - System.monotonic_time(:millisecond) - start_time
-        else
-          timeout
-        end
-
-      recv_response(entries, acc, conn, ref, timeout)
-    end
-  end
-
-  @doc """
   See `Mint.HTTP.set_mode/2`.
   """
   @impl true

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -530,6 +530,136 @@ defmodule Mint.HTTP1 do
   end
 
   @doc """
+  TODO
+
+  ## Examples
+
+      iex> {:ok, conn} = Mint.HTTP1.connect(:https, "httpbin.org", 443, mode: :passive)
+      iex> {:ok, conn, ref} = Mint.HTTP1.request(conn, "GET", "/status/user-agent", [], nil)
+      iex> {:ok, _conn, response} = Mint.HTTP1.recv_response(conn, ref, 5000)
+      iex> response
+      %{
+        status: 201,
+        headers: [
+          {"date", ...},
+          ...
+        ],
+        body: "{\\n  \\"user-agent\\": \\"mint/1.6.2\\"\\n}\\n"
+      }
+  """
+  def recv_response(conn, ref, timeout) do
+    recv_response(conn, ref, timeout, %{status: nil, headers: [], body: ""}, fn
+      conn, {:status, status}, acc ->
+        {:cont, conn, %{acc | status: status}}
+
+      conn, {:headers, headers}, acc ->
+        {:cont, conn, update_in(acc.headers, &(&1 ++ headers))}
+
+      conn, {:data, data}, acc ->
+        {:cont, conn, update_in(acc.body, &(&1 <> data))}
+
+      conn, :done, acc ->
+        {:cont, conn, acc}
+    end)
+  end
+
+  @doc """
+  TODO
+
+  ## Examples
+
+      iex> {:ok, conn} = Mint.HTTP1.connect(:https, "httpbin.org", 443, mode: :passive)
+      iex> {:ok, conn, ref} = Mint.HTTP1.request(conn, "GET", "/user-agent", [], nil)
+      iex> {:ok, _conn, _acc} =
+      ...>   Mint.HTTP1.recv_response(conn, ref, 5000, nil, fn
+      ...>   conn, entry, acc ->
+      ...>     IO.inspect(entry)
+      ...>     {:cont, conn, acc}
+      ...>   end)
+
+  Outputs:
+
+      {:status, 201}
+      {:headers, [{"date", ...}, ...]}
+      {:data, "{\\n  \\"user-agent\\": \\"mint/1.6.2\\"\\n}\\n"}
+      :done
+  """
+  def recv_response(conn, ref, timeout, acc, fun) do
+    recv_response([], acc, fun, conn, ref, timeout)
+  end
+
+  defp recv_response([{:status, ref, status} | rest], acc, fun, conn, ref, timeout) do
+    case fun.(conn, {:status, status}, acc) do
+      {:cont, conn, acc} ->
+        recv_response(rest, acc, fun, conn, ref, timeout)
+
+      {:halt, conn, acc} ->
+        {:ok, conn, acc}
+
+      other ->
+        raise ArgumentError,
+              "expected {:cont, conn, acc} or {:halt, conn, acc}, got: #{inspect(other)}"
+    end
+  end
+
+  defp recv_response([{:headers, ref, headers} | rest], acc, fun, conn, ref, timeout) do
+    case fun.(conn, {:headers, headers}, acc) do
+      {:cont, conn, acc} ->
+        recv_response(rest, acc, fun, conn, ref, timeout)
+
+      {:halt, conn, acc} ->
+        {:ok, conn, acc}
+
+      other ->
+        raise ArgumentError,
+              "expected {:cont, conn, acc} or {:halt, conn, acc}, got: #{inspect(other)}"
+    end
+  end
+
+  defp recv_response([{:data, ref, data} | rest], acc, fun, conn, ref, timeout) do
+    case fun.(conn, {:data, data}, acc) do
+      {:cont, conn, acc} ->
+        recv_response(rest, acc, fun, conn, ref, timeout)
+
+      {:halt, conn, acc} ->
+        {:ok, conn, acc}
+
+      other ->
+        raise ArgumentError,
+              "expected {:cont, conn, acc} or {:halt, conn, acc}, got: #{inspect(other)}"
+    end
+  end
+
+  defp recv_response([{:done, ref} | _], acc, fun, conn, ref, _timeout) do
+    case fun.(conn, :done, acc) do
+      {:cont, conn, acc} ->
+        {:ok, conn, acc}
+
+      {:halt, conn, acc} ->
+        {:ok, conn, acc}
+
+      other ->
+        raise ArgumentError,
+              "expected {:cont, conn, acc} or {:halt, conn, acc}, got: #{inspect(other)}"
+    end
+  end
+
+  defp recv_response([], acc, fun, conn, ref, timeout) do
+    start_time = System.monotonic_time(:millisecond)
+
+    with {:ok, conn, entries} <- recv(conn, 0, timeout) do
+      timeout =
+        if is_integer(timeout) do
+          timeout - System.monotonic_time(:millisecond) - start_time
+        else
+          timeout
+        end
+
+      recv_response(entries, acc, fun, conn, ref, timeout)
+    end
+  end
+
+  @doc """
   See `Mint.HTTP.set_mode/2`.
   """
   @impl true

--- a/test/http_test.exs
+++ b/test/http_test.exs
@@ -1,4 +1,4 @@
 defmodule Mint.HTTPTest do
   use ExUnit.Case, async: true
-  doctest Mint.HTTP, except: [recv_response: 3]
+  doctest Mint.HTTP, except: [request_and_response: 6]
 end

--- a/test/http_test.exs
+++ b/test/http_test.exs
@@ -1,4 +1,4 @@
 defmodule Mint.HTTPTest do
   use ExUnit.Case, async: true
-  doctest Mint.HTTP
+  doctest Mint.HTTP, except: [recv_response: 3]
 end

--- a/test/support/mint/http1/test_server.ex
+++ b/test/support/mint/http1/test_server.ex
@@ -1,17 +1,17 @@
 defmodule Mint.HTTP1.TestServer do
-  def start do
+  def start(fun \\ nil) do
     {:ok, listen_socket} = :gen_tcp.listen(0, mode: :binary, packet: :raw)
     server_ref = make_ref()
     parent = self()
 
-    spawn_link(fn -> loop(listen_socket, parent, server_ref) end)
+    spawn_link(fn -> loop(listen_socket, parent, server_ref, fun) end)
 
     with {:ok, port} <- :inet.port(listen_socket) do
       {:ok, port, server_ref}
     end
   end
 
-  defp loop(listen_socket, parent, server_ref) do
+  defp loop(listen_socket, parent, server_ref, fun) do
     case :gen_tcp.accept(listen_socket) do
       {:ok, socket} ->
         send(parent, {server_ref, socket})
@@ -22,7 +22,11 @@ defmodule Mint.HTTP1.TestServer do
           {:error, :einval} -> :ok
         end
 
-        loop(listen_socket, parent, server_ref)
+        if fun do
+          fun.(%{socket: socket, parent: parent})
+        end
+
+        loop(listen_socket, parent, server_ref, fun)
 
       {:error, :closed} ->
         :ok


### PR DESCRIPTION
I'd like to propose to add a `Mint.HTTP1.recv_response/3` that improve ergonomics of making one off requests:

```elixir
iex> {:ok, conn} = Mint.HTTP.connect(:https, "httpbin.org", 443, mode: :passive)
iex> {:ok, conn, ref} = Mint.HTTP.request(conn, "GET", "/user-agent", [], nil)
iex> {:ok, conn, response} = Mint.HTTP.recv_response(conn, ref, 5000)
iex> Mint.HTTP1.close(conn)
iex> response
%{
  status: 200,
  headers: [
    {"date", ...},
    ...
  ],
  body: "{\n  \"user-agent\": \"mint/1.6.2\"\n}\n"
}
```

There is a bunch of libraries which are simply make one off requests, to name a few: tzdata, goth/aws_credentials (they have their own pool, make one off request every ~hour), esbuild/tailwind.

To play the devils advocate, esbuild/tailwind are simply using httpc, copy-pasting these [secure ssl defaults from EEF Security WG](https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/inets).