### PR TITLE
Run CI against erlang 27.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - erlang: "27.0"
+          - erlang: "27.1"
             elixir: "1.17"
             lint: true
             coverage: true


### PR DESCRIPTION
Not completely sure what the CI/coverage strategy is but it seemed like: Test these old versions and the newest one! So, I thought I'd upgrade the newest one.

Didn't upgrade the runner os as erlang 23 is only covered by ubuntu 20.04: https://github.com/erlef/setup-beam?tab=readme-ov-file#compatibility-between-operating-system-and-erlangotp

This will reach EOL in a couple of months. So, testing against erlang 23 will be quite a bit tougher then.