### PR TITLE
Allow not validating target

### DIFF
--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -126,8 +126,8 @@ defmodule Mint.HTTP1 do
        because HTTP/1.1 header names are case-insensitive. *Available since v1.6.0*.
     * `:skip_target_validation` - (boolean) if set to `true` the target of a request
        will not be validated. You might want this if you deal with non standard-
-       conform URIs but need to preserve them. The default is to validate the request
-       target. *Available since v1.?.?*
+       conforming URIs but need to preserve them. The default is to validate the request
+       target. *Available since v1.7.0*.
 
   """
   @spec connect(Types.scheme(), Types.address(), :inet.port_number(), keyword()) ::

--- a/lib/mint/http1/request.ex
+++ b/lib/mint/http1/request.ex
@@ -3,9 +3,9 @@ defmodule Mint.HTTP1.Request do
 
   import Mint.HTTP1.Parse
 
-  def encode(method, target, headers, body) do
+  def encode(method, target, headers, body, skip_target_validation \\ false) do
     body = [
-      encode_request_line(method, target),
+      encode_request_line(method, target, skip_target_validation),
       encode_headers(headers),
       "\r\n",
       encode_body(body)
@@ -16,8 +16,8 @@ defmodule Mint.HTTP1.Request do
     {:mint, reason} -> {:error, reason}
   end
 
-  defp encode_request_line(method, target) do
-    validate_target!(target)
+  defp encode_request_line(method, target, skip_target_validation) do
+    unless skip_target_validation, do: validate_target!(target)
     [method, ?\s, target, " HTTP/1.1\r\n"]
   end
 

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -548,7 +548,7 @@ defmodule Mint.HTTP1Test do
              request_string("""
              GET / HTTP/1.1
              host: localhost:#{port}
-             user-agent: mint/#{Mix.Project.config()[:version]}
+             user-agent: #{mint_user_agent()}
 
              \
              """)
@@ -570,7 +570,7 @@ defmodule Mint.HTTP1Test do
                request_string("""
                GET / HTTP/1.1
                host: localhost
-               user-agent: mint/#{Mix.Project.config()[:version]}
+               user-agent: #{mint_user_agent()}
 
                \
                """)
@@ -591,7 +591,7 @@ defmodule Mint.HTTP1Test do
                GET / HTTP/1.1
                content-length: 4
                host: localhost:#{port}
-               user-agent: mint/#{Mix.Project.config()[:version]}
+               user-agent: #{mint_user_agent()}
 
                body\
                """)
@@ -607,7 +607,7 @@ defmodule Mint.HTTP1Test do
                request_string("""
                GET / HTTP/1.1
                host: localhost:#{port}
-               user-agent: mint/#{Mix.Project.config()[:version]}
+               user-agent: #{mint_user_agent()}
 
                \
                """)
@@ -626,7 +626,7 @@ defmodule Mint.HTTP1Test do
                request_string("""
                GET / HTTP/1.1
                host: localhost:#{port}
-               user-agent: mint/#{Mix.Project.config()[:version]}
+               user-agent: #{mint_user_agent()}
                content-length: 10
 
                body\
@@ -787,7 +787,7 @@ defmodule Mint.HTTP1Test do
                GET %% HTTP/1.1
                content-length: 4
                host: localhost:#{port}
-               user-agent: mint/#{Mix.Project.config()[:version]}
+               user-agent: #{mint_user_agent()}
 
                body\
                """)
@@ -804,7 +804,7 @@ defmodule Mint.HTTP1Test do
                GET / HTTP/1.1
                transfer-encoding: chunked
                host: localhost:#{port}
-               user-agent: mint/#{Mix.Project.config()[:version]}
+               user-agent: #{mint_user_agent()}
 
                \
                """)
@@ -827,7 +827,7 @@ defmodule Mint.HTTP1Test do
                request_string("""
                GET / HTTP/1.1
                host: localhost:#{port}
-               user-agent: mint/#{Mix.Project.config()[:version]}
+               user-agent: #{mint_user_agent()}
                transfer-encoding: chunked
 
                \
@@ -847,7 +847,7 @@ defmodule Mint.HTTP1Test do
                request_string("""
                GET / HTTP/1.1
                host: localhost:#{port}
-               user-agent: mint/#{Mix.Project.config()[:version]}
+               user-agent: #{mint_user_agent()}
                transfer-encoding: gzip,chunked
 
                \
@@ -871,7 +871,7 @@ defmodule Mint.HTTP1Test do
                request_string("""
                GET / HTTP/1.1
                host: localhost:#{port}
-               user-agent: mint/#{Mix.Project.config()[:version]}
+               user-agent: #{mint_user_agent()}
                transfer-encoding: identity
 
                \
@@ -891,7 +891,7 @@ defmodule Mint.HTTP1Test do
                request_string("""
                GET / HTTP/1.1
                host: localhost:#{port}
-               user-agent: mint/#{Mix.Project.config()[:version]}
+               user-agent: #{mint_user_agent()}
                content-length: 5
 
                \
@@ -909,7 +909,7 @@ defmodule Mint.HTTP1Test do
                GET / HTTP/1.1
                transfer-encoding: chunked
                host: localhost:#{port}
-               user-agent: mint/#{Mix.Project.config()[:version]}
+               user-agent: #{mint_user_agent()}
 
                \
                """)
@@ -929,7 +929,7 @@ defmodule Mint.HTTP1Test do
                POST / HTTP/1.1
                transfer-encoding: chunked
                host: localhost:#{port}
-               user-agent: mint/#{Mix.Project.config()[:version]}
+               user-agent: #{mint_user_agent()}
 
                \
                """)
@@ -1029,4 +1029,6 @@ defmodule Mint.HTTP1Test do
   defp stream_message_bytewise(<<>>, conn, responses) do
     {:ok, conn, responses}
   end
+
+  defp mint_user_agent, do: "mint/#{Mix.Project.config()[:version]}"
 end

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -1030,5 +1030,6 @@ defmodule Mint.HTTP1Test do
     {:ok, conn, responses}
   end
 
-  defp mint_user_agent, do: "mint/#{Mix.Project.config()[:version]}"
+  @mint_user_agent "mint/#{Mix.Project.config()[:version]}"
+  defp mint_user_agent, do: @mint_user_agent
 end

--- a/test/mint/http1/request_test.exs
+++ b/test/mint/http1/request_test.exs
@@ -33,24 +33,6 @@ defmodule Mint.HTTP1.RequestTest do
                """)
     end
 
-    @invalid_request_targets ["/ /", "/%foo", "/foo%x"]
-    test "validates request target" do
-      for invalid_target <- @invalid_request_targets do
-        assert Request.encode("GET", invalid_target, [], nil) ==
-                 {:error, {:invalid_request_target, invalid_target}}
-      end
-
-      request = encode_request("GET", "/foo%20bar", [], nil)
-      assert String.starts_with?(request, request_string("GET /foo%20bar HTTP/1.1"))
-    end
-
-    test "can optionally skip validating the request target" do
-      for invalid_target <- @invalid_request_targets do
-        request = encode_request("GET", invalid_target, [], nil, true)
-        assert String.starts_with?(request, request_string("GET #{invalid_target} HTTP/1.1"))
-      end
-    end
-
     test "invalid header name" do
       assert Request.encode("GET", "/", [{"f oo", "bar"}], nil) ==
                {:error, {:invalid_header_name, "f oo"}}
@@ -84,8 +66,8 @@ defmodule Mint.HTTP1.RequestTest do
     end
   end
 
-  defp encode_request(method, target, headers, body, skip_target_validation \\ false) do
-    assert {:ok, iodata} = Request.encode(method, target, headers, body, skip_target_validation)
+  defp encode_request(method, target, headers, body) do
+    assert {:ok, iodata} = Request.encode(method, target, headers, body)
     IO.iodata_to_binary(iodata)
   end
 


### PR DESCRIPTION
As discussed in https://github.com/elixir-mint/mint/issues/453

I tried to follow the guidance of `case_sensitive_headers` so
that these options are treated somewhat similarly.

I tried to keep with the patterns of surrounding code, if you want anything changed/I missed something - happy to do so!

In a separate commit I also included a small nicety as I saw the definition of the mint user agent duplicated over the tests. Happy to roll that back though.

Some questions/remarks inline.

Thanks for all your work! :green_heart: 

Tasks left for me:
* [ ] Check if this actually fixes what I reported in #453 :)

![IMG_20220619_184733](https://github.com/user-attachments/assets/f68b435d-7ffb-4489-8997-c43b2f6fb780)
