### PR TITLE
Add documentation note about protocol specific options to Mint.HTTP.connect/4

### DIFF
--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -238,6 +238,10 @@ defmodule Mint.HTTP do
       server. See `Mint.HTTP2.put_settings/2` for more information. This is only used
       in HTTP/2 connections.
 
+  There may be further protocol specific options that only take effect when the corresponding
+  connection is established. Check `Mint.HTTP1.connect/4` and `Mint.HTTP2.connect/4` for
+  details.
+
   ## Protocol negotiation
 
   If both `:http1` and `:http2` are present in the list passed in the `:protocols` option,


### PR DESCRIPTION
Most outside documenation (Finch, Req) links just to `Mint.HTTP.connect/4` for documentation. That makes it somewhat hard to find both the case insesntitive header options as well as the not validating target options.

Not sure it's worth duplicating them there, so I figured I'd just point to them - even if HTTP2 has no custom options as of now.

That's, of course, debatable. So, happy about feedback/improvements :)

Thank you!