### PR TITLE
fix: fix delegation of `open?` function to use the same function name

### DIFF
--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -530,7 +530,7 @@ defmodule Mint.HTTP do
   """
   @impl true
   @spec open?(t(), :read | :write) :: boolean()
-  def open?(conn, type \\ :write), do: conn_apply(conn, :open, [conn, type])
+  def open?(conn, type \\ :write), do: conn_apply(conn, :open?, [conn, type])
 
   @doc """
   Sends a request to the connected server.


### PR DESCRIPTION
Just upgraded to Mint 1.7 and started getting errors whenever trying to use it - 

```
** (UndefinedFunctionError) function Mint.HTTP1.open/2 is undefined or private. Did you mean:

      * open?/1
      * open?/2

    (mint 1.7.0) Mint.HTTP1.open(%Mint.HTTP1{host: "hex.pm", port: 443, request: nil, streaming_request: nil, socket: {:sslsocket, {:gen_tcp, #Port<0.148>, :tls_connection, :undefined}, [#PID<0.7456.0>, #PID<0.7455.0>]}, transport: Mint.Core.Transport.SSL, mode: :passive, scheme_as_string: "https", case_sensitive_headers: false, skip_target_validation: false, requests: {[], []}, state: :open, buffer: "", proxy_headers: [], private: %{}, log: false}, :write)
    (finch 0.19.0) lib/finch/http1/pool.ex:283: Finch.HTTP1.Pool.transfer_if_open/3
    (finch 0.19.0) lib/finch/http1/pool.ex:70: anonymous fn/10 in Finch.HTTP1.Pool.request/6
    (nimble_pool 1.1.0) lib/nimble_pool.ex:462: NimblePool.checkout!/4
    (finch 0.19.0) lib/finch/http1/pool.ex:52: Finch.HTTP1.Pool.request/6
    (finch 0.19.0) lib/finch.ex:493: anonymous fn/4 in Finch.request/3
    (telemetry 1.3.0) /Users/rebecca/Projects/book/testing/tunez_starter/deps/telemetry/src/telemetry.erl:324: :telemetry.span/3
    (req 0.5.8) lib/req/finch.ex:253: Req.Finch.run_finch_request/3
```

I think this is the cause!