### PR TITLE
declare types for Mint.HTTPError.reason() and Mint.TransportError.reason()

### DIFF
--- a/lib/mint/http_error.ex
+++ b/lib/mint/http_error.ex
@@ -53,9 +53,8 @@ defmodule Mint.HTTPError do
            | {:unexpected_status, non_neg_integer()}
            | {:unexpected_trailing_responses, list()}}
 
-  @type t() :: %__MODULE__{
-          reason: HTTP1.error_reason() | HTTP2.error_reason() | proxy_reason() | term()
-        }
+  @type reason :: HTTP1.error_reason() | HTTP2.error_reason() | proxy_reason() | term()
+  @type t() :: %__MODULE__{reason: reason()}
 
   defexception [:reason, :module]
 

--- a/lib/mint/transport_error.ex
+++ b/lib/mint/transport_error.ex
@@ -55,7 +55,8 @@ defmodule Mint.TransportError do
       reason_type
     end
 
-  @type t() :: %__MODULE__{reason: unquote(reason_type) | term()}
+  @type reason :: unquote(reason_type) | term()
+  @type t() :: %__MODULE__{reason: reason()}
 
   defexception [:reason]
 


### PR DESCRIPTION
Would be nice to refer to these types in Finch
https://github.com/sneako/finch/pull/341