### PR TITLE
Run HTTP/2 integration tests against local Caddy instead of nghttp2.org

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,6 +2,9 @@
 	local_certs
 	skip_install_trust
 	storage file_system /caddy_storage
+	servers :{$HTTPBIN_HTTP_PORT:8080} {
+		protocols h1 h2c
+	}
 }
 
 https://localhost:{$HTTPBIN_HTTPS_PORT:8443} {

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ TINYPROXY_PORT=8887 docker compose up --detach
 TINYPROXY_PORT=8887 mix test --include proxy
 ```
 
-Available port variables: `TINYPROXY_PORT` (default 8888), `TINYPROXY_AUTH_PORT` (default 8889), `HTTPBIN_HTTP_PORT` (default 8080), `HTTPBIN_HTTPS_PORT` (default 8443).
+Available port variables: `TINYPROXY_PORT` (default 8888), `TINYPROXY_AUTH_PORT` (default 8889), `HTTPBIN_HTTP_PORT` (default 8080), `HTTPBIN_HTTPS_PORT` (default 8443), `HTTPBIN_H2C_PORT` (default 8081).
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,3 +34,4 @@ services:
       - "./Caddyfile:/etc/caddy/Caddyfile:z"
     ports:
       - "${HTTPBIN_HTTPS_PORT:-8443}:${HTTPBIN_HTTPS_PORT:-8443}"
+      - "${HTTPBIN_H2C_PORT:-8081}:${HTTPBIN_HTTP_PORT:-8080}"

--- a/test/mint/http2/integration_test.exs
+++ b/test/mint/http2/integration_test.exs
@@ -32,14 +32,10 @@ defmodule HTTP2.IntegrationTest do
     end
   end
 
-  test "TCP - nghttp2.org" do
-    assert {:ok, %HTTP2{} = conn} = HTTP2.connect(:http, "nghttp2.org", 80)
+  test "TCP - h2c prior knowledge" do
+    assert {:ok, %HTTP2{} = conn} = HTTP2.connect(:http, HttpBin.host(), HttpBin.h2c_port())
 
-    assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/httpbin/", [], nil)
-
-    # For some reason, we get an SSL message sneaking in here. Instead of going
-    # crazy trying to debug it, for now let's just swallow it.
-    assert_receive {:ssl, _socket, _data}, 1000
+    assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/", [], nil)
 
     assert {:ok, %HTTP2{} = conn, responses} = receive_stream(conn)
 
@@ -152,32 +148,6 @@ defmodule HTTP2.IntegrationTest do
       assert {_, [{:done, ^ref}]} = Enum.split_while(rest, &match?({:data, ^ref, _}, &1))
 
       assert status == 301
-      assert is_list(headers)
-
-      assert conn.buffer == ""
-      assert HTTP2.open?(conn)
-    end
-  end
-
-  describe "nghttp2.org/httpbin" do
-    @describetag connect: {"nghttp2.org", 443}
-
-    test "ping", %{conn: conn} do
-      assert {:ok, %HTTP2{} = conn, ref} = HTTP2.ping(conn)
-      assert {:ok, %HTTP2{} = conn, [{:pong, ^ref}]} = receive_stream(conn)
-      assert conn.buffer == ""
-      assert HTTP2.open?(conn)
-    end
-
-    test "GET /", %{conn: conn} do
-      assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/httpbin/", [], nil)
-
-      assert {:ok, %HTTP2{} = conn, responses} = receive_stream(conn)
-
-      assert [{:status, ^ref, status}, {:headers, ^ref, headers} | rest] = responses
-      assert {_, [{:done, ^ref}]} = Enum.split_while(rest, &match?({:data, ^ref, _}, &1))
-
-      assert status == 200
       assert is_list(headers)
 
       assert conn.buffer == ""

--- a/test/mint/http2/integration_test.exs
+++ b/test/mint/http2/integration_test.exs
@@ -101,7 +101,7 @@ defmodule HTTP2.IntegrationTest do
   end
 
   describe "twitter.com" do
-    @moduletag connect: {"twitter.com", 443}
+    @describetag connect: {"twitter.com", 443}
     @browser_user_agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"
 
     test "ping", %{conn: conn} do

--- a/test/support/mint/http_bin.ex
+++ b/test/support/mint/http_bin.ex
@@ -17,6 +17,10 @@ defmodule Mint.HttpBin do
     get_env_port("HTTPBIN_HTTPS_PORT", 8443)
   end
 
+  def h2c_port() do
+    get_env_port("HTTPBIN_H2C_PORT", 8081)
+  end
+
   def proxy_port() do
     get_env_port("TINYPROXY_PORT", 8888)
   end


### PR DESCRIPTION
The tests hitting nghttp2.org/httpbin/ had been failing on every CI run because the upstream httpbin backend behind nghttpx returns 502 to GitHub Actions runners. Enable h2c on the Caddy docker service (via a new HTTPBIN_H2C_PORT, default 8081, since the existing HTTPBIN_HTTP_PORT mapping goes directly to httpbin), point the TCP h2c test at it, and drop the duplicate "nghttp2.org/httpbin" describe block (ping and GET are already covered by the local "httpbin.org" block).