### PR TITLE
Don't close the connection on a receive timeout

### DIFF
--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -551,6 +551,7 @@ defmodule Mint.HTTP1 do
     case conn.transport.recv(conn.socket, byte_count, timeout) do
       {:ok, data} -> handle_data(conn, data)
       {:error, %Mint.TransportError{reason: :closed}} -> handle_close(conn)
+      {:error, %Mint.TransportError{reason: :timeout} = error} -> {:error, conn, error, []}
       {:error, error} -> handle_transport_error(conn, error)
     end
   end

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -874,6 +874,9 @@ defmodule Mint.HTTP2 do
       {:error, %TransportError{reason: :closed}} ->
         handle_closed(conn)
 
+      {:error, %TransportError{reason: :timeout} = error} ->
+        {:error, conn, error, []}
+
       {:error, error} ->
         {:error, %{conn | state: :closed}, error, _responses = []}
     end


### PR DESCRIPTION
Its often useful to be able to test that a connection has no data waiting on it like `recv(socket, 0, 0)`. This PR handles the timeout error and returns it to the caller, rather than defaulting to closing the connection.