### PR TITLE
Replace deprecated xref: [exclude:] with elixirc_options: [no_warn_undefined:]

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,9 +13,9 @@ defmodule Mint.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
 
-      # Xref
-      xref: [
-        exclude: [
+      # Suppress "undefined function" warnings for optional/runtime deps.
+      elixirc_options: [
+        no_warn_undefined: [
           {:ssl, :cipher_suites, 1},
           {:public_key, :cacerts_get, 0},
           CAStore


### PR DESCRIPTION
Elixir 1.20 deprecates the project-level `xref: [exclude: ...]` option:

> `xref: [exclude: ...]` in your mix.exs file is deprecated, instead use: `elixirc_options: [no_warn_undefined: ...]`

This swaps it for `elixirc_options: [no_warn_undefined: ...]`, which has been the canonical compiler option since Elixir 1.7. mint requires `~> 1.12`, so the replacement is valid across the entire supported range — no version gating needed.

The exclusion list is unchanged, so behaviour is identical — the same entries are suppressed: `CAStore`, `{:ssl, :cipher_suites, 1}`, `{:public_key, :cacerts_get, 0}`.

Verified `mix compile --force --warnings-as-errors` stays clean with the optional `castore` dep absent — i.e. `no_warn_undefined` suppresses the `CAStore` reference exactly as the old `xref` exclude did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)