### PR TITLE
Send origin Host header for plain-HTTP proxied requests

### DIFF
--- a/lib/mint/unsafe_proxy.ex
+++ b/lib/mint/unsafe_proxy.ex
@@ -81,7 +81,7 @@ defmodule Mint.UnsafeProxy do
         body \\ nil
       ) do
     path = request_line(conn, path)
-    headers = headers ++ conn.proxy_headers
+    headers = put_new_host_header(headers, conn) ++ conn.proxy_headers
 
     case module.request(state, method, path, headers, body) do
       {:ok, state, request} -> {:ok, %{conn | state: state}, request}
@@ -203,5 +203,29 @@ defmodule Mint.UnsafeProxy do
   @impl true
   def request_body_window(%__MODULE__{module: module, state: state}, ref) do
     module.request_body_window(state, ref)
+  end
+
+  # When proxying over plain HTTP, the request is sent to the proxy but its Host
+  # header must identify the origin server, not the proxy (RFC 7230, sec. 5.4).
+  # Mint.HTTP1 would otherwise default the Host header to the proxy's address,
+  # since its connection points at the proxy. We set it here (unless the caller
+  # already provided one) so Mint.HTTP1's `put_new` leaves the origin's Host in
+  # place.
+  defp put_new_host_header(headers, conn) do
+    if Enum.any?(headers, fn {name, _value} -> String.downcase(name, :ascii) == "host" end) do
+      headers
+    else
+      [{"Host", host_header_value(conn)} | headers]
+    end
+  end
+
+  # Mirrors the default-port handling in Mint.HTTP1: omit the port when it is the
+  # default for the scheme.
+  defp host_header_value(%UnsafeProxy{scheme: scheme, hostname: hostname, port: port}) do
+    if URI.default_port(Atom.to_string(scheme)) == port do
+      hostname
+    else
+      "#{hostname}:#{port}"
+    end
   end
 end

--- a/lib/mint/unsafe_proxy.ex
+++ b/lib/mint/unsafe_proxy.ex
@@ -212,7 +212,7 @@ defmodule Mint.UnsafeProxy do
   # already provided one) so Mint.HTTP1's `put_new` leaves the origin's Host in
   # place.
   defp put_new_host_header(headers, conn) do
-    if Enum.any?(headers, fn {name, _value} -> String.downcase(name, :ascii) == "host" end) do
+    if Enum.any?(headers, fn {name, _value} -> Mint.Core.Headers.lower_raw(name) == "host" end) do
       headers
     else
       [{"Host", host_header_value(conn)} | headers]

--- a/test/mint/unsafe_proxy_host_header_test.exs
+++ b/test/mint/unsafe_proxy_host_header_test.exs
@@ -1,0 +1,87 @@
+defmodule Mint.UnsafeProxyHostHeaderTest do
+  use ExUnit.Case, async: true
+
+  alias Mint.HTTP
+
+  # Regression for #446. When proxying over plain HTTP, the request is sent to
+  # the proxy but its Host header must identify the origin server, not the proxy.
+  # These tests use a local TCP server as the "proxy" and inspect the raw bytes
+  # it receives, so they need no live proxy or internet connection. They live in
+  # their own module (rather than in unsafe_proxy_test.exs) so they run in the
+  # default suite instead of being excluded by that module's `:proxy` tag.
+
+  test "sets the Host header to the origin, not the proxy" do
+    request = proxied_request(:http, "example.com", 80, "GET", "/", [])
+
+    # The request line still targets the absolute origin URI (proxy form)...
+    assert request =~ "GET http://example.com/ HTTP/1.1"
+
+    # ...but the Host header is the origin, not the proxy's "localhost:<port>".
+    assert host_header(request) == "host: example.com"
+    refute request =~ ~r/localhost:\d+/
+  end
+
+  test "keeps the origin port in the Host header when it is not the default" do
+    request = proxied_request(:http, "example.com", 8080, "GET", "/", [])
+
+    assert host_header(request) == "host: example.com:8080"
+  end
+
+  test "does not override a caller-supplied Host header" do
+    request = proxied_request(:http, "example.com", 80, "GET", "/", [{"host", "other.example"}])
+
+    assert host_header(request) == "host: other.example"
+  end
+
+  # Connects to `host:port` through a local TCP server acting as the proxy, sends
+  # one request, and returns the raw bytes the proxy received.
+  defp proxied_request(scheme, host, port, method, path, headers) do
+    proxy_port = start_capturing_proxy()
+
+    assert {:ok, conn} =
+             HTTP.connect(scheme, host, port, proxy: {:http, "localhost", proxy_port, []})
+
+    assert {:ok, _conn, _ref} = HTTP.request(conn, method, path, headers, nil)
+
+    assert_receive {:proxy_request, request}, 2000
+    request
+  end
+
+  # Starts a one-shot TCP server that accepts a single connection, reads the
+  # request head, and forwards the raw bytes back to the test process. It owns
+  # the accepted socket and does its own passive `recv`, so there is no socket
+  # ownership race with the test process.
+  defp start_capturing_proxy do
+    test_pid = self()
+
+    {:ok, listen_socket} =
+      :gen_tcp.listen(0, mode: :binary, packet: :raw, active: false, reuseaddr: true)
+
+    {:ok, port} = :inet.port(listen_socket)
+
+    spawn_link(fn ->
+      {:ok, socket} = :gen_tcp.accept(listen_socket)
+      send(test_pid, {:proxy_request, recv_request_head(socket)})
+      :gen_tcp.close(socket)
+      :gen_tcp.close(listen_socket)
+    end)
+
+    port
+  end
+
+  defp recv_request_head(socket, acc \\ "") do
+    if String.contains?(acc, "\r\n\r\n") do
+      acc
+    else
+      {:ok, data} = :gen_tcp.recv(socket, 0, 2000)
+      recv_request_head(socket, acc <> data)
+    end
+  end
+
+  defp host_header(request) do
+    request
+    |> String.split("\r\n")
+    |> Enum.find(&(&1 |> String.downcase() |> String.starts_with?("host:")))
+    |> String.downcase()
+  end
+end


### PR DESCRIPTION
## Fix `Host` header for plain-HTTP proxied requests

Fixes #446.

### Problem

When connecting to an origin server through a plain-HTTP proxy —
`Mint.HTTP.connect(:http, "example.com", 80, proxy: {:http, "127.0.0.1", 9055, []})` —
Mint sends the **proxy's** address as the `Host` header instead of the origin's:

```
GET http://example.com/ HTTP/1.1
host: 127.0.0.1:9055        <-- wrong: this is the proxy, not the origin
user-agent: mint/1.9.3
```

hackney and HTTPoison send `Host: example.com` for the identical proxied
request. Per RFC 7230 §5.4 the `Host` header must identify the origin server,
so Mint's behavior breaks virtual-hosted origins, proxy logging, and any server
behind the proxy that routes on `Host`.

### Root cause

`Mint.UnsafeProxy` (the plain-HTTP, non-tunnel proxy) holds an `Mint.HTTP1`
connection whose socket points at the *proxy*. In `Mint.UnsafeProxy.request/5`
the request path is correctly rewritten to the absolute origin URI, but no
`Host` header is set, so it falls through to `Mint.HTTP1`, whose
`add_default_headers/2` fills in `Host` from *its* connection — i.e. the proxy's
host and port (`lib/mint/http1.ex:1170`, `default_host_header/1` at
`lib/mint/http1.ex:1174`). `UnsafeProxy` is the only layer that knows the
origin, so the origin `Host` has to be set there.

### Fix

`lib/mint/unsafe_proxy.ex` — `request/5` now sets the `Host` header to the
origin server (host, plus port when it is not the scheme default) before
delegating to `Mint.HTTP1`. Because `Mint.HTTP1` uses `put_new` for its default
`Host`, the origin value is left untouched. A caller-supplied `Host` header
(matched case-insensitively) is still respected, matching the direct-connection
behavior.

### Tests

New `test/mint/unsafe_proxy_host_header_test.exs`. It uses a local one-shot TCP
server as the "proxy" and inspects the raw request bytes, so it needs no live
proxy or internet connection and runs in the default suite (it is a separate
module so it isn't excluded by `unsafe_proxy_test.exs`'s `:proxy` moduletag).
Covers: origin `Host` for a default port, origin `host:port` for a non-default
port, and that a caller-supplied `Host` is not overridden.

### Verification

Before (on `main`):

```
GET http://example.com/ HTTP/1.1
host: localhost:60234
user-agent: mint/1.9.3
```

After:

```
GET http://example.com/ HTTP/1.1
user-agent: mint/1.9.3
host: example.com
```

Commands:

```
$ mix test test/mint/unsafe_proxy_host_header_test.exs
...
3 passed

# whole offline suite unaffected
$ mix test --exclude requires_internet_connection
304 passed, 51 excluded

$ mix format --check-formatted   # clean
$ mix compile --warnings-as-errors   # clean
$ mix dialyzer   # done (passed successfully)
```

The new tests fail before the fix (`host: localhost:<port>` / `host:
example.com:8080`) and pass after.

### Compatibility

No public API change. Only the `Host` header for plain-HTTP proxied requests is
affected, bringing it in line with RFC 7230 §5.4 and with hackney/HTTPoison.
Callers that explicitly pass their own `Host` header are unaffected. Tunnel
(CONNECT) proxying and direct connections are untouched.

---

*AI-authored and AI-reviewed; not yet human-reviewed.*
