### PR TITLE
Support processing HTTP/1.1 headers as they arrive

### DIFF
--- a/.dialyzer_ignore
+++ b/.dialyzer_ignore
@@ -1,5 +1,5 @@
 lib/mint/tunnel_proxy.ex:50
-lib/mint/http1.ex:999
+lib/mint/http1.ex:1062
 lib/mint/unsafe_proxy.ex:173
 lib/mint/unsafe_proxy.ex:198
 test/support

--- a/.dialyzer_ignore
+++ b/.dialyzer_ignore
@@ -1,5 +1,5 @@
 lib/mint/tunnel_proxy.ex:50
-lib/mint/http1.ex:1062
+lib/mint/http1.ex:1063
 lib/mint/unsafe_proxy.ex:173
 lib/mint/unsafe_proxy.ex:198
 test/support

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -844,8 +844,11 @@ defmodule Mint.HTTP do
     * `{:headers, request_ref, headers}` - returned when the server replied
       with a list of headers. Headers are in the form `{header_name, header_value}`
       with `header_name` and `header_value` being strings. A single `:headers` response
-      will come after the `:status` response. A single `:headers` response may come
-      after all the `:data` responses if **trailer headers** are present.
+      will come after the `:status` response and a single `:headers` response may come
+      after all the `:data` responses if **trailer headers** are present unless
+      `:stream_headers` is enabled (only available for HTTP/1.1 connections), in which
+      case any number of `:headers` responses (including none) may come after the
+      `:status` response and/or after all the `:data` responses.
 
     * `{:data, request_ref, binary}` - returned when the server replied with
       a chunk of response body (as a binary). The request shouldn't be considered done

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -104,6 +104,7 @@ defmodule Mint.HTTP1 do
     :case_sensitive_headers,
     :skip_target_validation,
     :max_header_list_size,
+    :stream_headers,
     requests: :queue.new(),
     state: :closed,
     buffer: "",
@@ -149,6 +150,11 @@ defmodule Mint.HTTP1 do
     * `:max_header_list_size` - (`t:pos_integer/0` or `:infinity`) the maximum number of
       bytes allowed in a response header section or chunked trailer section. This includes
       header names, values, and line delimiters. Defaults to 256 KiB. *Available since 1.9.2*.
+
+    * `:stream_headers` - (`t:boolean/0`) if set to `true`, response headers and trailer headers
+      will be emitted as they are parsed, rather than buffered until the complete header section
+      is received. When enabled, you may receive multiple `{:headers, ref, headers}` responses
+      for a single request. Defaults to `false`. *Available since v1.10.0*.
 
   """
   @spec connect(Types.scheme(), Types.address(), :inet.port_number(), keyword()) ::
@@ -238,6 +244,7 @@ defmodule Mint.HTTP1 do
         case_sensitive_headers: Keyword.get(opts, :case_sensitive_headers, false),
         skip_target_validation: Keyword.get(opts, :skip_target_validation, false),
         max_header_list_size: max_header_list_size,
+        stream_headers: Keyword.get(opts, :stream_headers, false),
         optional_responses: validate_optional_response_values(opts)
       }
 
@@ -758,7 +765,12 @@ defmodule Mint.HTTP1 do
       {:ok, :eof, rest} ->
         case add_header_bytes(conn, request, byte_size(data) - byte_size(rest)) do
           {:ok, request} ->
-            responses = [{:headers, request.ref, Enum.reverse(headers)} | responses]
+            responses =
+              case {conn.stream_headers, headers} do
+                {true, []} -> responses
+                {_, headers} -> [{:headers, request.ref, Enum.reverse(headers)} | responses]
+              end
+
             request = %{request | state: :body, headers_buffer: [], headers_size: 0}
             conn = %{conn | buffer: "", request: request}
             decode(:body, conn, rest, responses)
@@ -770,7 +782,19 @@ defmodule Mint.HTTP1 do
       :more ->
         case check_header_section_size(conn, request.headers_size + byte_size(data)) do
           :ok ->
-            request = %{request | headers_buffer: headers}
+            {responses, headers_buffer} =
+              cond do
+                not conn.stream_headers ->
+                  {responses, headers}
+
+                headers != [] ->
+                  {[{:headers, request.ref, Enum.reverse(headers)} | responses], []}
+
+                true ->
+                  {responses, []}
+              end
+
+            request = %{request | headers_buffer: headers_buffer}
             conn = %{conn | buffer: data, request: request}
             {:ok, conn, responses}
 
@@ -950,7 +974,24 @@ defmodule Mint.HTTP1 do
       :more ->
         case check_header_section_size(conn, conn.request.headers_size + byte_size(data)) do
           :ok ->
-            request = %{conn.request | body: {:chunked, :trailer}, headers_buffer: headers}
+            {responses, headers_buffer} =
+              cond do
+                not conn.stream_headers ->
+                  {responses, headers}
+
+                headers != [] ->
+                  responses =
+                    headers
+                    |> Headers.remove_unallowed_trailer()
+                    |> add_trailer_headers(conn.request.ref, responses)
+
+                  {responses, []}
+
+                true ->
+                  {responses, []}
+              end
+
+            request = %{conn.request | body: {:chunked, :trailer}, headers_buffer: headers_buffer}
             conn = %{conn | buffer: data, request: request}
             {:ok, conn, responses}
 

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -751,7 +751,7 @@ defmodule Mint.HTTP1 do
   end
 
   defp decode_headers(conn, request, data, responses, headers) do
-    case Response.decode_header(data) do
+    case do_decode_header(data, conn.stream_headers) do
       {:ok, {name, value}, rest} ->
         headers = [{name, value} | headers]
 
@@ -942,7 +942,7 @@ defmodule Mint.HTTP1 do
   end
 
   defp decode_trailer_headers(conn, data, responses, headers) do
-    case Response.decode_header(data) do
+    case do_decode_header(data, conn.stream_headers) do
       {:ok, {name, value}, rest} ->
         case add_header_bytes(conn, conn.request, byte_size(data) - byte_size(rest)) do
           {:ok, request} ->
@@ -1001,6 +1001,25 @@ defmodule Mint.HTTP1 do
 
       :error ->
         {:error, conn, wrap_error(:invalid_trailer_header), responses}
+    end
+  end
+
+  defp do_decode_header(data, false), do: Response.decode_header(data)
+
+  defp do_decode_header(data, true) do
+    # By default, :erlang.decode_packet/3 asks for more data when a packet
+    # containing a full header ends with a line feed (likely to handle line
+    # folding). If we get a :more response on a packet that ends with a line
+    # feed, we append a sentinel byte and attempt to decode again.
+    with :more <- Response.decode_header(data) do
+      data_size = byte_size(data)
+
+      with <<_::binary-size(data_size - 1), 10>> <- data,
+           {:ok, {name, value}, rest} <- Response.decode_header(<<data::binary, 0>>) do
+        {:ok, {name, value}, binary_part(rest, 0, byte_size(rest) - 1)}
+      else
+        _ -> :more
+      end
     end
   end
 

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -1004,9 +1004,9 @@ defmodule Mint.HTTP1 do
     end
   end
 
-  defp do_decode_header(data, false), do: Response.decode_header(data)
+  defp do_decode_header(data, false = _stream_headers), do: Response.decode_header(data)
 
-  defp do_decode_header(data, true) do
+  defp do_decode_header(data, true = _stream_headers) do
     # By default, :erlang.decode_packet/3 asks for more data when a packet
     # containing a full header ends with a line feed (likely to handle line
     # folding). If we get a :more response on a packet that ends with a line
@@ -1014,9 +1014,11 @@ defmodule Mint.HTTP1 do
     with :more <- Response.decode_header(data) do
       data_size = byte_size(data)
 
-      with <<_::binary-size(data_size - 1), 10>> <- data,
-           {:ok, {name, value}, rest} <- Response.decode_header(<<data::binary, 0>>) do
-        {:ok, {name, value}, binary_part(rest, 0, byte_size(rest) - 1)}
+      with <<_::binary-size(^data_size - 1), ?\n>> <- data do
+        case Response.decode_header(<<data::binary, 0>>) do
+          {:ok, {name, value}, <<0>>} -> {:ok, {name, value}, ""}
+          result -> result
+        end
       else
         _ -> :more
       end

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -1014,13 +1014,14 @@ defmodule Mint.HTTP1 do
     with :more <- Response.decode_header(data) do
       data_size = byte_size(data)
 
-      with <<_::binary-size(^data_size - 1), ?\n>> <- data do
-        case Response.decode_header(<<data::binary, 0>>) do
-          {:ok, {name, value}, <<0>>} -> {:ok, {name, value}, ""}
-          result -> result
-        end
-      else
-        _ -> :more
+      case data do
+        <<_::binary-size(^data_size - 1), ?\n>> ->
+          with {:ok, {name, value}, <<0>>} <- Response.decode_header(<<data::binary, 0>>) do
+            {:ok, {name, value}, ""}
+          end
+
+        _ ->
+          :more
       end
     end
   end

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -751,7 +751,7 @@ defmodule Mint.HTTP1 do
   end
 
   defp decode_headers(conn, request, data, responses, headers) do
-    case do_decode_header(data, conn.stream_headers) do
+    case decode_header(data, conn.stream_headers) do
       {:ok, {name, value}, rest} ->
         headers = [{name, value} | headers]
 
@@ -766,9 +766,10 @@ defmodule Mint.HTTP1 do
         case add_header_bytes(conn, request, byte_size(data) - byte_size(rest)) do
           {:ok, request} ->
             responses =
-              case {conn.stream_headers, headers} do
-                {true, []} -> responses
-                {_, headers} -> [{:headers, request.ref, Enum.reverse(headers)} | responses]
+              if conn.stream_headers and headers == [] do
+                responses
+              else
+                [{:headers, request.ref, Enum.reverse(headers)} | responses]
               end
 
             request = %{request | state: :body, headers_buffer: [], headers_size: 0}
@@ -942,7 +943,7 @@ defmodule Mint.HTTP1 do
   end
 
   defp decode_trailer_headers(conn, data, responses, headers) do
-    case do_decode_header(data, conn.stream_headers) do
+    case decode_header(data, conn.stream_headers) do
       {:ok, {name, value}, rest} ->
         case add_header_bytes(conn, conn.request, byte_size(data) - byte_size(rest)) do
           {:ok, request} ->
@@ -1004,9 +1005,9 @@ defmodule Mint.HTTP1 do
     end
   end
 
-  defp do_decode_header(data, false = _stream_headers), do: Response.decode_header(data)
+  defp decode_header(data, false = _stream_headers), do: Response.decode_header(data)
 
-  defp do_decode_header(data, true = _stream_headers) do
+  defp decode_header(data, true = _stream_headers) do
     # By default, :erlang.decode_packet/3 asks for more data when a packet
     # containing a full header ends with a line feed (likely to handle line
     # folding). If we get a :more response on a packet that ends with a line

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -1280,10 +1280,13 @@ defmodule Mint.HTTP1Test do
       [conn: conn, server_socket: server_socket]
     end
 
-    test "emits all complete headers from a chunk at once when stream_headers is true", %{conn: conn} do
+    test "emits all complete headers from a chunk at once when stream_headers is true", %{
+      conn: conn
+    } do
       {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
 
-      assert {:ok, conn, [_status]} = HTTP1.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
+      assert {:ok, conn, [_status]} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
 
       # Send two complete headers plus start of third header in one chunk
       # This should emit the two complete headers together
@@ -1302,7 +1305,8 @@ defmodule Mint.HTTP1Test do
     test "emits multiple headers from one packet together", %{conn: conn} do
       {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
 
-      assert {:ok, conn, [_status]} = HTTP1.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
+      assert {:ok, conn, [_status]} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
 
       assert {:ok, _conn, responses} =
                HTTP1.stream(conn, {:tcp, conn.socket, "Foo: Bar\r\nBaz: Boz\r\n\r\n"})
@@ -1314,7 +1318,8 @@ defmodule Mint.HTTP1Test do
     test "handles partial headers with streaming", %{conn: conn} do
       {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
 
-      assert {:ok, conn, [_status]} = HTTP1.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
+      assert {:ok, conn, [_status]} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
 
       # Send first header with partial second header
       assert {:ok, conn, [header1]} = HTTP1.stream(conn, {:tcp, conn.socket, "Foo: Bar\r\nB"})
@@ -1323,6 +1328,29 @@ defmodule Mint.HTTP1Test do
       # Complete second header and end headers
       assert {:ok, _conn, [header2]} = HTTP1.stream(conn, {:tcp, conn.socket, "az: Boz\r\n\r\n"})
       assert {:headers, ^ref, [{"baz", "Boz"}]} = header2
+    end
+
+    test "emits header immediately when packet ends exactly after LF", %{conn: conn} do
+      {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
+
+      assert {:ok, conn, [_status]} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
+
+      # Send a complete header ending exactly at packet boundary (no subsequent bytes)
+      assert {:ok, conn, responses} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "X-Progress: 50\r\n"})
+
+      assert [{:headers, ^ref, [{"x-progress", "50"}]}] = responses
+
+      # Send another complete header ending exactly at packet boundary
+      assert {:ok, conn, responses} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "X-Progress: 100\r\n"})
+
+      assert [{:headers, ^ref, [{"x-progress", "100"}]}] = responses
+
+      # End the header section
+      assert {:ok, _conn, responses} = HTTP1.stream(conn, {:tcp, conn.socket, "\r\n"})
+      assert [] = responses
     end
 
     test "streams trailer headers from same chunk together", %{conn: conn} do
@@ -1370,6 +1398,39 @@ defmodule Mint.HTTP1Test do
       assert [trailer, done] = responses
       assert {:headers, ^ref, [{"x-custom-trailer", "allowed"}]} = trailer
       assert {:done, ^ref} = done
+    end
+
+    test "emits trailer header immediately when packet ends exactly after LF", %{conn: conn} do
+      {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
+
+      assert {:ok, conn, [_status]} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
+
+      assert {:ok, conn, [_headers]} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "Transfer-Encoding: chunked\r\n\r\n"})
+
+      assert {:ok, conn, responses} = HTTP1.stream(conn, {:tcp, conn.socket, "5\r\nhello\r\n"})
+      assert [{:data, ^ref, "hello"}] = responses
+
+      # Send last chunk (ending exactly at boundary)
+      assert {:ok, conn, responses} = HTTP1.stream(conn, {:tcp, conn.socket, "0\r\n"})
+      assert [] = responses
+
+      # Send a complete trailer header ending exactly at packet boundary (no subsequent bytes)
+      assert {:ok, conn, responses} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "X-Trailer-1: value1\r\n"})
+
+      assert [{:headers, ^ref, [{"x-trailer-1", "value1"}]}] = responses
+
+      # Send another complete trailer header ending exactly at packet boundary
+      assert {:ok, conn, responses} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "X-Trailer-2: value2\r\n"})
+
+      assert [{:headers, ^ref, [{"x-trailer-2", "value2"}]}] = responses
+
+      # End the trailer section
+      assert {:ok, _conn, responses} = HTTP1.stream(conn, {:tcp, conn.socket, "\r\n"})
+      assert [{:done, ^ref}] = responses
     end
   end
 

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -1338,9 +1338,12 @@ defmodule Mint.HTTP1Test do
 
       # Send a complete header ending exactly at packet boundary (no subsequent bytes)
       assert {:ok, conn, responses} =
-               HTTP1.stream(conn, {:tcp, conn.socket, "X-Progress: 50\r\n"})
+               HTTP1.stream(
+                 conn,
+                 {:tcp, conn.socket, "X-Progress: 50\r\nX-Other: value\r\n"}
+               )
 
-      assert [{:headers, ^ref, [{"x-progress", "50"}]}] = responses
+      assert [{:headers, ^ref, [{"x-progress", "50"}, {"x-other", "value"}]}] = responses
 
       # Send another complete header ending exactly at packet boundary
       assert {:ok, conn, responses} =

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -1273,6 +1273,106 @@ defmodule Mint.HTTP1Test do
     end
   end
 
+  describe "stream_headers option" do
+    setup %{port: port} do
+      assert {:ok, conn} = HTTP1.connect(:http, "localhost", port, stream_headers: true)
+      assert_receive {_server_ref, server_socket}
+      [conn: conn, server_socket: server_socket]
+    end
+
+    test "emits all complete headers from a chunk at once when stream_headers is true", %{conn: conn} do
+      {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
+
+      assert {:ok, conn, [_status]} = HTTP1.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
+
+      # Send two complete headers plus start of third header in one chunk
+      # This should emit the two complete headers together
+      assert {:ok, conn, [headers1]} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "Foo: Bar\r\nBaz: Boz\r\nQux"})
+
+      assert {:headers, ^ref, [{"foo", "Bar"}, {"baz", "Boz"}]} = headers1
+
+      # Complete the third header and end headers section
+      assert {:ok, _conn, [headers2]} =
+               HTTP1.stream(conn, {:tcp, conn.socket, ": Quux\r\n\r\n"})
+
+      assert {:headers, ^ref, [{"qux", "Quux"}]} = headers2
+    end
+
+    test "emits multiple headers from one packet together", %{conn: conn} do
+      {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
+
+      assert {:ok, conn, [_status]} = HTTP1.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
+
+      assert {:ok, _conn, responses} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "Foo: Bar\r\nBaz: Boz\r\n\r\n"})
+
+      assert [headers] = responses
+      assert {:headers, ^ref, [{"foo", "Bar"}, {"baz", "Boz"}]} = headers
+    end
+
+    test "handles partial headers with streaming", %{conn: conn} do
+      {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
+
+      assert {:ok, conn, [_status]} = HTTP1.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
+
+      # Send first header with partial second header
+      assert {:ok, conn, [header1]} = HTTP1.stream(conn, {:tcp, conn.socket, "Foo: Bar\r\nB"})
+      assert {:headers, ^ref, [{"foo", "Bar"}]} = header1
+
+      # Complete second header and end headers
+      assert {:ok, _conn, [header2]} = HTTP1.stream(conn, {:tcp, conn.socket, "az: Boz\r\n\r\n"})
+      assert {:headers, ^ref, [{"baz", "Boz"}]} = header2
+    end
+
+    test "streams trailer headers from same chunk together", %{conn: conn} do
+      {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
+
+      assert {:ok, conn, [_status]} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
+
+      assert {:ok, conn, [_headers]} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "Transfer-Encoding: chunked\r\n\r\n"})
+
+      assert {:ok, conn, responses} = HTTP1.stream(conn, {:tcp, conn.socket, "5\r\nhello\r\n"})
+      assert [{:data, ^ref, "hello"}] = responses
+
+      # Send last chunk and trailer headers in one chunk
+      assert {:ok, _conn, responses} =
+               HTTP1.stream(
+                 conn,
+                 {:tcp, conn.socket, "0\r\nX-Trailer-1: value1\r\nX-Trailer-2: value2\r\n\r\n"}
+               )
+
+      assert [trailers, done] = responses
+      assert {:headers, ^ref, [{"x-trailer-1", "value1"}, {"x-trailer-2", "value2"}]} = trailers
+      assert {:done, ^ref} = done
+    end
+
+    test "filters unallowed trailer headers when streaming", %{conn: conn} do
+      {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
+
+      assert {:ok, conn, [_status]} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
+
+      assert {:ok, conn, [_headers]} =
+               HTTP1.stream(conn, {:tcp, conn.socket, "Transfer-Encoding: chunked\r\n\r\n"})
+
+      # Send last chunk with allowed and unallowed trailer headers
+      assert {:ok, _conn, responses} =
+               HTTP1.stream(
+                 conn,
+                 {:tcp, conn.socket,
+                  "0\r\nContent-Length: 100\r\nX-Custom-Trailer: allowed\r\n\r\n"}
+               )
+
+      # Content-Length should be filtered out, only X-Custom-Trailer should appear
+      assert [trailer, done] = responses
+      assert {:headers, ^ref, [{"x-custom-trailer", "allowed"}]} = trailer
+      assert {:done, ^ref} = done
+    end
+  end
+
   @mint_user_agent "mint/#{Mix.Project.config()[:version]}"
   defp mint_user_agent, do: @mint_user_agent
 end


### PR DESCRIPTION
## Introduction

This is my attempt at implementing the feature requested in [Issue 452](https://github.com/elixir-mint/mint/issues/452).

The motivation for the change was the `X-ClickHouse-Progress` header system used by the [ClickHouse HTTP interface](https://clickhouse.com/docs/concepts/features/interfaces/http) (which I strongly suspect was the reason behind the aforementioned issue).

## Implementation

This PR adds a new `:stream_headers` option for HTTP/1.1 connections that allows headers and trailers to be emitted as responses as soon as they're available instead of buffering them until they've all arrived. A few nuances about enabling this feature:
- All _complete_ headers from a single chunk are emitted at the same time
- It's theoretically possible to receive **NO** `:headers` responses for a given request whereas, when not streaming headers, an empty list would be emitted. This change is explicitly laid out in the `Mint.HTTP` documentation.

This feature is opt-in, meaning there should be no changes for existing users.

## Tesing

All existing tests pass and new stream headers tests were added to the HTTP/1.1 connection test module.

Open to any and all feedback 😃 